### PR TITLE
Fix ad loaders callback issue

### DIFF
--- a/addons/admob/src/api/AdView.gd
+++ b/addons/admob/src/api/AdView.gd
@@ -45,30 +45,12 @@ func _init(ad_unit_id : String, ad_size : AdSize, ad_position : AdPosition.Value
 		}
 
 		_uid = _plugin.create(ad_view_dictionary)
-		_plugin.connect("on_ad_clicked", func(uid : int): 
-			if uid == _uid:
-				ad_listener.on_ad_clicked.call_deferred()
-			)
-		_plugin.connect("on_ad_closed", func(uid : int): 
-			if uid == _uid:
-				ad_listener.on_ad_closed.call_deferred()
-			)
-		_plugin.connect("on_ad_failed_to_load", func(uid : int, load_ad_error_dictionary : Dictionary): 
-			if uid == _uid:
-				ad_listener.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))
-			)
-		_plugin.connect("on_ad_impression", func(uid : int): 
-			if uid == _uid:
-				ad_listener.on_ad_impression.call_deferred()
-			)
-		_plugin.connect("on_ad_loaded", func(uid : int): 
-			if uid == _uid:
-				ad_listener.on_ad_loaded.call_deferred()
-			)
-		_plugin.connect("on_ad_opened", func(uid : int): 
-			if uid == _uid:
-				ad_listener.on_ad_opened.call_deferred()
-			)
+		_plugin.connect("on_ad_clicked", _on_ad_clicked)
+		_plugin.connect("on_ad_closed", _on_ad_closed)
+		_plugin.connect("on_ad_failed_to_load", _on_ad_failed_to_load)
+		_plugin.connect("on_ad_impression", _on_ad_impression)
+		_plugin.connect("on_ad_loaded", _on_ad_loaded)
+		_plugin.connect("on_ad_opened", _on_ad_opened)
 
 func load_ad(ad_request : AdRequest) -> void:
 	if _plugin:
@@ -105,3 +87,27 @@ func get_height_in_pixels() -> int:
 	if _plugin:
 		return _plugin.get_height_in_pixels(_uid)
 	return -1
+
+func _on_ad_clicked(uid : int) -> void: 
+	if uid == _uid:
+		ad_listener.on_ad_clicked.call_deferred()
+
+func _on_ad_closed(uid : int) -> void: 
+	if uid == _uid:
+		ad_listener.on_ad_closed.call_deferred()
+
+func _on_ad_failed_to_load(uid : int, load_ad_error_dictionary : Dictionary) -> void: 
+	if uid == _uid:
+		ad_listener.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))
+
+func _on_ad_impression(uid : int) -> void: 
+	if uid == _uid:
+		ad_listener.on_ad_impression.call_deferred()
+
+func _on_ad_loaded(uid : int) -> void: 
+	if uid == _uid:
+		ad_listener.on_ad_loaded.call_deferred()
+
+func _on_ad_opened(uid : int) -> void: 
+	if uid == _uid:
+		ad_listener.on_ad_opened.call_deferred()

--- a/addons/admob/src/api/InterstitialAd.gd
+++ b/addons/admob/src/api/InterstitialAd.gd
@@ -42,23 +42,28 @@ func destroy() -> void:
 
 func register_callbacks() -> void:
 	if _plugin:
-		_plugin.connect("on_interstitial_ad_clicked", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_clicked.call_deferred()
-			)
-		_plugin.connect("on_interstitial_ad_dismissed_full_screen_content", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_dismissed_full_screen_content.call_deferred()
-			)
-		_plugin.connect("on_interstitial_ad_failed_to_show_full_screen_content", func(uid : int, ad_error_dictionary : Dictionary):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_failed_to_show_full_screen_content.call_deferred(AdError.create(ad_error_dictionary))
-			)
-		_plugin.connect("on_interstitial_ad_impression", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_impression.call_deferred()
-			)
-		_plugin.connect("on_interstitial_ad_showed_full_screen_content", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_showed_full_screen_content.call_deferred()
-			)
+		_plugin.connect("on_interstitial_ad_clicked", _on_interstitial_ad_clicked)
+		_plugin.connect("on_interstitial_ad_dismissed_full_screen_content", _on_interstitial_ad_dismissed_full_screen_content)
+		_plugin.connect("on_interstitial_ad_failed_to_show_full_screen_content", _on_interstitial_ad_failed_to_show_full_screen_content)
+		_plugin.connect("on_interstitial_ad_impression", _on_interstitial_ad_impression)
+		_plugin.connect("on_interstitial_ad_showed_full_screen_content", _on_interstitial_ad_showed_full_screen_content)
+
+func _on_interstitial_ad_clicked(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_clicked.call_deferred()
+
+func _on_interstitial_ad_dismissed_full_screen_content(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_dismissed_full_screen_content.call_deferred()
+
+func _on_interstitial_ad_failed_to_show_full_screen_content(uid : int, ad_error_dictionary : Dictionary) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_failed_to_show_full_screen_content.call_deferred(AdError.create(ad_error_dictionary))
+
+func _on_interstitial_ad_impression(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_impression.call_deferred()
+
+func _on_interstitial_ad_showed_full_screen_content(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_showed_full_screen_content.call_deferred()

--- a/addons/admob/src/api/InterstitialAdLoader.gd
+++ b/addons/admob/src/api/InterstitialAdLoader.gd
@@ -25,8 +25,6 @@ extends MobileSingletonPlugin
 
 static var _plugin = _get_plugin("PoingGodotAdMobInterstitialAd")
 
-var ad_unit_id : String
-var ad_request : AdRequest
 var interstitial_ad_load_callback : InterstitialAdLoadCallback
 var _uid : int
 
@@ -38,19 +36,21 @@ func load(
 	ad_unit_id : String, 
 	ad_request : AdRequest, 
 	interstitial_ad_load_callback := InterstitialAdLoadCallback.new()) -> void:
-
+	
 	if _plugin:
-		self.ad_unit_id = ad_unit_id
-		self.ad_request = ad_request
 		self.interstitial_ad_load_callback = interstitial_ad_load_callback
+		_plugin.connect("on_interstitial_ad_loaded", _on_interstitial_ad_loaded, CONNECT_DEFERRED)
+		_plugin.connect("on_interstitial_ad_failed_to_load", _on_interstitial_ad_failed_to_load, CONNECT_DEFERRED)
+		reference()
 		_plugin.load(ad_unit_id, ad_request.convert_to_dictionary(), ad_request.keywords, _uid)
-		_plugin.connect("on_interstitial_ad_loaded", _on_interstitial_ad_loaded, CONNECT_ONE_SHOT)
-		_plugin.connect("on_interstitial_ad_failed_to_load", _on_interstitial_ad_failed_to_load, CONNECT_ONE_SHOT)
-
+		
 func _on_interstitial_ad_loaded(uid : int) -> void:
 	if uid == _uid:
-		interstitial_ad_load_callback.on_ad_loaded.call_deferred(InterstitialAd.new(uid))
+		interstitial_ad_load_callback.on_ad_loaded.call(InterstitialAd.new(uid))
+		unreference.call_deferred()
 
 func _on_interstitial_ad_failed_to_load(uid : int, load_ad_error_dictionary : Dictionary) -> void: 
 	if uid == _uid:
-		interstitial_ad_load_callback.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))
+		interstitial_ad_load_callback.on_ad_failed_to_load.call(LoadAdError.create(load_ad_error_dictionary))
+		unreference.call_deferred()
+

--- a/addons/admob/src/api/InterstitialAdLoader.gd
+++ b/addons/admob/src/api/InterstitialAdLoader.gd
@@ -40,12 +40,17 @@ func load(
 	interstitial_ad_load_callback := InterstitialAdLoadCallback.new()) -> void:
 
 	if _plugin:
+		self.ad_unit_id = ad_unit_id
+		self.ad_request = ad_request
+		self.interstitial_ad_load_callback = interstitial_ad_load_callback
 		_plugin.load(ad_unit_id, ad_request.convert_to_dictionary(), ad_request.keywords, _uid)
-		_plugin.connect("on_interstitial_ad_loaded", func(uid : int):
-			if uid == _uid:
-				interstitial_ad_load_callback.on_ad_loaded.call_deferred(InterstitialAd.new(uid))
-		, CONNECT_ONE_SHOT)
-		_plugin.connect("on_interstitial_ad_failed_to_load", func(uid : int, load_ad_error_dictionary : Dictionary): 
-			if uid == _uid:
-				interstitial_ad_load_callback.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))
-		, CONNECT_ONE_SHOT)
+		_plugin.connect("on_interstitial_ad_loaded", _on_interstitial_ad_loaded, CONNECT_ONE_SHOT)
+		_plugin.connect("on_interstitial_ad_failed_to_load", _on_interstitial_ad_failed_to_load, CONNECT_ONE_SHOT)
+
+func _on_interstitial_ad_loaded(uid : int) -> void:
+	if uid == _uid:
+		interstitial_ad_load_callback.on_ad_loaded.call_deferred(InterstitialAd.new(uid))
+
+func _on_interstitial_ad_failed_to_load(uid : int, load_ad_error_dictionary : Dictionary) -> void: 
+	if uid == _uid:
+		interstitial_ad_load_callback.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))

--- a/addons/admob/src/api/MobileAds.gd
+++ b/addons/admob/src/api/MobileAds.gd
@@ -25,15 +25,15 @@ extends MobileSingletonPlugin
 
 static var _plugin := _get_plugin("PoingGodotAdMob")
 
+static var _current_on_initialization_complete_listener : OnInitializationCompleteListener = null
+
 static func initialize(on_initialization_complete_listener : OnInitializationCompleteListener = null) -> void:
 	if _plugin:
 		_plugin.initialize()
 		
 		if on_initialization_complete_listener:
-			_plugin.connect("on_initialization_complete", func(admob_initialization_status : Dictionary):
-				var initialization_status := InitializationStatus.create(admob_initialization_status)
-				on_initialization_complete_listener.on_initialization_complete.call_deferred(initialization_status)
-			, CONNECT_ONE_SHOT)
+			_current_on_initialization_complete_listener = on_initialization_complete_listener
+			_plugin.connect("on_initialization_complete", _on_initialization_complete, CONNECT_ONE_SHOT)
 
 static func set_request_configuration(request_configuration : RequestConfiguration) -> void:
 	if _plugin:
@@ -49,3 +49,7 @@ static func get_initialization_status() -> InitializationStatus:
 static func set_ios_app_pause_on_background(pause : bool) -> void:
 	if _plugin and OS.get_name() == "iOS":
 		_plugin.set_ios_app_pause_on_background(pause)
+
+static func _on_initialization_complete(admob_initialization_status : Dictionary) -> void:
+	var initialization_status := InitializationStatus.create(admob_initialization_status)
+	_current_on_initialization_complete_listener.on_initialization_complete.call_deferred(initialization_status)

--- a/addons/admob/src/api/RewardedAd.gd
+++ b/addons/admob/src/api/RewardedAd.gd
@@ -32,13 +32,13 @@ func _init(uid : int):
 	self._uid = uid
 	register_callbacks()
 
+var _on_user_earned_reward_listener : OnUserEarnedRewardListener
+
 func show(on_user_earned_reward_listener := OnUserEarnedRewardListener.new()) -> void:
 	if _plugin:
+		self._on_user_earned_reward_listener = on_user_earned_reward_listener
 		_plugin.show(_uid)
-		_plugin.connect("on_rewarded_ad_user_earned_reward", func(uid : int, rewarded_item_dictionary : Dictionary):
-			if uid == _uid:
-				on_user_earned_reward_listener.on_user_earned_reward.call_deferred(RewardedItem.create(rewarded_item_dictionary))
-			)
+		_plugin.connect("on_rewarded_ad_user_earned_reward", _on_rewarded_ad_user_earned_reward)
 
 func destroy() -> void:
 	if _plugin:
@@ -50,23 +50,32 @@ func set_server_side_verification_options(server_side_verification_options : Ser
 
 func register_callbacks() -> void:
 	if _plugin:
-		_plugin.connect("on_rewarded_ad_clicked", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_clicked.call_deferred()
-			)
-		_plugin.connect("on_rewarded_ad_dismissed_full_screen_content", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_dismissed_full_screen_content.call_deferred()
-			)
-		_plugin.connect("on_rewarded_ad_failed_to_show_full_screen_content", func(uid : int, ad_error_dictionary : Dictionary):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_failed_to_show_full_screen_content.call_deferred(AdError.create(ad_error_dictionary))
-			)
-		_plugin.connect("on_rewarded_ad_impression", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_impression.call_deferred()
-			)
-		_plugin.connect("on_rewarded_ad_showed_full_screen_content", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_showed_full_screen_content.call_deferred()
-			)
+		_plugin.connect("on_rewarded_ad_clicked", _on_rewarded_ad_clicked)
+		_plugin.connect("on_rewarded_ad_dismissed_full_screen_content", _on_rewarded_ad_dismissed_full_screen_content)
+		_plugin.connect("on_rewarded_ad_failed_to_show_full_screen_content", _on_rewarded_ad_failed_to_show_full_screen_content)
+		_plugin.connect("on_rewarded_ad_impression", _on_rewarded_ad_impression)
+		_plugin.connect("on_rewarded_ad_showed_full_screen_content", _on_rewarded_ad_showed_full_screen_content)
+
+func _on_rewarded_ad_user_earned_reward(uid : int, rewarded_item_dictionary : Dictionary) -> void:
+	if uid == _uid:
+		_on_user_earned_reward_listener.on_user_earned_reward.call_deferred(RewardedItem.create(rewarded_item_dictionary))
+
+func _on_rewarded_ad_clicked(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_clicked.call_deferred()
+
+func _on_rewarded_ad_dismissed_full_screen_content(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_dismissed_full_screen_content.call_deferred()
+
+func _on_rewarded_ad_failed_to_show_full_screen_content(uid : int, ad_error_dictionary : Dictionary) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_failed_to_show_full_screen_content.call_deferred(AdError.create(ad_error_dictionary))
+
+func _on_rewarded_ad_impression(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_impression.call_deferred()
+
+func _on_rewarded_ad_showed_full_screen_content(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_showed_full_screen_content.call_deferred()

--- a/addons/admob/src/api/RewardedAdLoader.gd
+++ b/addons/admob/src/api/RewardedAdLoader.gd
@@ -40,12 +40,17 @@ func load(
 	rewarded_ad_load_callback := RewardedAdLoadCallback.new()) -> void:
 
 	if _plugin:
+		self.ad_unit_id = ad_unit_id
+		self.ad_request = ad_request
+		self.rewarded_ad_load_callback = rewarded_ad_load_callback
 		_plugin.load(ad_unit_id, ad_request.convert_to_dictionary(), ad_request.keywords, _uid)
-		_plugin.connect("on_rewarded_ad_loaded", func(uid : int):
-			if uid == _uid:
-				rewarded_ad_load_callback.on_ad_loaded.call_deferred(RewardedAd.new(uid))
-		, CONNECT_ONE_SHOT)
-		_plugin.connect("on_rewarded_ad_failed_to_load", func(uid : int, load_ad_error_dictionary : Dictionary): 
-			if uid == _uid:
-				rewarded_ad_load_callback.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))
-		, CONNECT_ONE_SHOT)
+		_plugin.connect("on_rewarded_ad_loaded", _on_rewarded_ad_loaded, CONNECT_ONE_SHOT)
+		_plugin.connect("on_rewarded_ad_failed_to_load", _on_rewarded_ad_failed_to_load, CONNECT_ONE_SHOT)
+
+func _on_rewarded_ad_loaded(uid : int) -> void:
+	if uid == _uid:
+		rewarded_ad_load_callback.on_ad_loaded.call_deferred(RewardedAd.new(uid))
+
+func _on_rewarded_ad_failed_to_load(uid : int, load_ad_error_dictionary : Dictionary) -> void: 
+	if uid == _uid:
+		rewarded_ad_load_callback.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))

--- a/addons/admob/src/api/RewardedAdLoader.gd
+++ b/addons/admob/src/api/RewardedAdLoader.gd
@@ -25,8 +25,6 @@ extends MobileSingletonPlugin
 
 static var _plugin = _get_plugin("PoingGodotAdMobRewardedAd")
 
-var ad_unit_id : String
-var ad_request : AdRequest
 var rewarded_ad_load_callback : RewardedAdLoadCallback
 var _uid : int
 
@@ -40,17 +38,19 @@ func load(
 	rewarded_ad_load_callback := RewardedAdLoadCallback.new()) -> void:
 
 	if _plugin:
-		self.ad_unit_id = ad_unit_id
-		self.ad_request = ad_request
 		self.rewarded_ad_load_callback = rewarded_ad_load_callback
+		_plugin.connect("on_rewarded_ad_loaded", _on_rewarded_ad_loaded, CONNECT_DEFERRED)
+		_plugin.connect("on_rewarded_ad_failed_to_load", _on_rewarded_ad_failed_to_load, CONNECT_DEFERRED)
+		reference()
 		_plugin.load(ad_unit_id, ad_request.convert_to_dictionary(), ad_request.keywords, _uid)
-		_plugin.connect("on_rewarded_ad_loaded", _on_rewarded_ad_loaded, CONNECT_ONE_SHOT)
-		_plugin.connect("on_rewarded_ad_failed_to_load", _on_rewarded_ad_failed_to_load, CONNECT_ONE_SHOT)
 
 func _on_rewarded_ad_loaded(uid : int) -> void:
 	if uid == _uid:
-		rewarded_ad_load_callback.on_ad_loaded.call_deferred(RewardedAd.new(uid))
+		rewarded_ad_load_callback.on_ad_loaded.call(RewardedAd.new(uid))
+		unreference.call_deferred()
 
 func _on_rewarded_ad_failed_to_load(uid : int, load_ad_error_dictionary : Dictionary) -> void: 
 	if uid == _uid:
-		rewarded_ad_load_callback.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))
+		rewarded_ad_load_callback.on_ad_failed_to_load.call(LoadAdError.create(load_ad_error_dictionary))
+		unreference.call_deferred()
+		

--- a/addons/admob/src/api/RewardedInterstitialAd.gd
+++ b/addons/admob/src/api/RewardedInterstitialAd.gd
@@ -32,13 +32,13 @@ func _init(uid : int):
 	self._uid = uid
 	register_callbacks()
 
+var _on_user_earned_reward_listener : OnUserEarnedRewardListener
+
 func show(on_user_earned_reward_listener := OnUserEarnedRewardListener.new()) -> void:
 	if _plugin:
+		self._on_user_earned_reward_listener = on_user_earned_reward_listener
 		_plugin.show(_uid)
-		_plugin.connect("on_rewarded_interstitial_ad_user_earned_reward", func(uid : int, rewarded_item_dictionary : Dictionary):
-			if uid == _uid:
-				on_user_earned_reward_listener.on_user_earned_reward.call_deferred(RewardedItem.create(rewarded_item_dictionary))
-			)
+		_plugin.connect("on_rewarded_interstitial_ad_user_earned_reward", _on_rewarded_interstitial_ad_user_earned_reward)
 
 func destroy() -> void:
 	if _plugin:
@@ -50,23 +50,32 @@ func set_server_side_verification_options(server_side_verification_options : Ser
 
 func register_callbacks() -> void:
 	if _plugin:
-		_plugin.connect("on_rewarded_interstitial_ad_clicked", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_clicked.call_deferred()
-			)
-		_plugin.connect("on_rewarded_interstitial_ad_dismissed_full_screen_content", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_dismissed_full_screen_content.call_deferred()
-			)
-		_plugin.connect("on_rewarded_interstitial_ad_failed_to_show_full_screen_content", func(uid : int, ad_error_dictionary : Dictionary):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_failed_to_show_full_screen_content.call_deferred(AdError.create(ad_error_dictionary))
-			)
-		_plugin.connect("on_rewarded_interstitial_ad_impression", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_impression.call_deferred()
-			)
-		_plugin.connect("on_rewarded_interstitial_ad_showed_full_screen_content", func(uid : int):
-			if uid == _uid:
-				full_screen_content_callback.on_ad_showed_full_screen_content.call_deferred()
-			)
+		_plugin.connect("on_rewarded_interstitial_ad_clicked", _on_rewarded_interstitial_ad_clicked)
+		_plugin.connect("on_rewarded_interstitial_ad_dismissed_full_screen_content", _on_rewarded_interstitial_ad_dismissed_full_screen_content)
+		_plugin.connect("on_rewarded_interstitial_ad_failed_to_show_full_screen_content", _on_rewarded_interstitial_ad_failed_to_show_full_screen_content)
+		_plugin.connect("on_rewarded_interstitial_ad_impression", _on_rewarded_interstitial_ad_impression)
+		_plugin.connect("on_rewarded_interstitial_ad_showed_full_screen_content", _on_rewarded_interstitial_ad_showed_full_screen_content)
+
+func _on_rewarded_interstitial_ad_user_earned_reward(uid : int, rewarded_item_dictionary : Dictionary) -> void:
+	if uid == _uid:
+		_on_user_earned_reward_listener.on_user_earned_reward.call_deferred(RewardedItem.create(rewarded_item_dictionary))
+
+func _on_rewarded_interstitial_ad_clicked(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_clicked.call_deferred()
+
+func _on_rewarded_interstitial_ad_dismissed_full_screen_content(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_dismissed_full_screen_content.call_deferred()
+
+func _on_rewarded_interstitial_ad_failed_to_show_full_screen_content(uid : int, ad_error_dictionary : Dictionary) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_failed_to_show_full_screen_content.call_deferred(AdError.create(ad_error_dictionary))
+
+func _on_rewarded_interstitial_ad_impression(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_impression.call_deferred()
+
+func _on_rewarded_interstitial_ad_showed_full_screen_content(uid : int) -> void:
+	if uid == _uid:
+		full_screen_content_callback.on_ad_showed_full_screen_content.call_deferred()

--- a/addons/admob/src/api/RewardedInterstitialAdLoader.gd
+++ b/addons/admob/src/api/RewardedInterstitialAdLoader.gd
@@ -40,12 +40,17 @@ func load(
 	rewarded_ad_load_callback := RewardedInterstitialAdLoadCallback.new()) -> void:
 
 	if _plugin:
+		self.ad_unit_id = ad_unit_id
+		self.ad_request = ad_request
+		self.rewarded_ad_load_callback = rewarded_ad_load_callback
 		_plugin.load(ad_unit_id, ad_request.convert_to_dictionary(), ad_request.keywords, _uid)
-		_plugin.connect("on_rewarded_interstitial_ad_loaded", func(uid : int):
-			if uid == _uid:
-				rewarded_ad_load_callback.on_ad_loaded.call_deferred(RewardedInterstitialAd.new(uid))
-		, CONNECT_ONE_SHOT)
-		_plugin.connect("on_rewarded_interstitial_ad_failed_to_load", func(uid : int, load_ad_error_dictionary : Dictionary): 
-			if uid == _uid:
-				rewarded_ad_load_callback.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))
-		, CONNECT_ONE_SHOT)
+		_plugin.connect("on_rewarded_interstitial_ad_loaded", _on_rewarded_interstitial_ad_loaded, CONNECT_ONE_SHOT)
+		_plugin.connect("on_rewarded_interstitial_ad_failed_to_load", _on_rewarded_interstitial_ad_failed_to_load, CONNECT_ONE_SHOT)
+
+func _on_rewarded_interstitial_ad_loaded(uid : int) -> void:
+	if uid == _uid:
+		rewarded_ad_load_callback.on_ad_loaded.call_deferred(RewardedInterstitialAd.new(uid))
+
+func _on_rewarded_interstitial_ad_failed_to_load(uid : int, load_ad_error_dictionary : Dictionary) -> void: 
+	if uid == _uid:
+		rewarded_ad_load_callback.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))

--- a/addons/admob/src/api/RewardedInterstitialAdLoader.gd
+++ b/addons/admob/src/api/RewardedInterstitialAdLoader.gd
@@ -25,8 +25,6 @@ extends MobileSingletonPlugin
 
 static var _plugin = _get_plugin("PoingGodotAdMobRewardedInterstitialAd")
 
-var ad_unit_id : String
-var ad_request : AdRequest
 var rewarded_ad_load_callback : RewardedInterstitialAdLoadCallback
 var _uid : int
 
@@ -40,17 +38,19 @@ func load(
 	rewarded_ad_load_callback := RewardedInterstitialAdLoadCallback.new()) -> void:
 
 	if _plugin:
-		self.ad_unit_id = ad_unit_id
-		self.ad_request = ad_request
 		self.rewarded_ad_load_callback = rewarded_ad_load_callback
+		_plugin.connect("on_rewarded_interstitial_ad_loaded", _on_rewarded_interstitial_ad_loaded, CONNECT_DEFERRED)
+		_plugin.connect("on_rewarded_interstitial_ad_failed_to_load", _on_rewarded_interstitial_ad_failed_to_load, CONNECT_DEFERRED)
+		reference()
 		_plugin.load(ad_unit_id, ad_request.convert_to_dictionary(), ad_request.keywords, _uid)
-		_plugin.connect("on_rewarded_interstitial_ad_loaded", _on_rewarded_interstitial_ad_loaded, CONNECT_ONE_SHOT)
-		_plugin.connect("on_rewarded_interstitial_ad_failed_to_load", _on_rewarded_interstitial_ad_failed_to_load, CONNECT_ONE_SHOT)
 
 func _on_rewarded_interstitial_ad_loaded(uid : int) -> void:
 	if uid == _uid:
-		rewarded_ad_load_callback.on_ad_loaded.call_deferred(RewardedInterstitialAd.new(uid))
+		rewarded_ad_load_callback.on_ad_loaded.call(RewardedInterstitialAd.new(uid))
+		unreference.call_deferred()
 
 func _on_rewarded_interstitial_ad_failed_to_load(uid : int, load_ad_error_dictionary : Dictionary) -> void: 
 	if uid == _uid:
-		rewarded_ad_load_callback.on_ad_failed_to_load.call_deferred(LoadAdError.create(load_ad_error_dictionary))
+		rewarded_ad_load_callback.on_ad_failed_to_load.call(LoadAdError.create(load_ad_error_dictionary))
+		unreference.call_deferred()
+		

--- a/addons/admob/src/ump/api/ConsentForm.gd
+++ b/addons/admob/src/ump/api/ConsentForm.gd
@@ -36,10 +36,11 @@ func show(on_consent_form_dismissed := func(form_error : FormError) : pass) -> v
 	if _plugin:
 		self._on_consent_form_dismissed_callback = on_consent_form_dismissed
 		_plugin.show(_uid)
-		_plugin.connect("on_consent_form_dismissed", _on_consent_form_dismissed, CONNECT_ONE_SHOT)
+		_plugin.connect("on_consent_form_dismissed", _on_consent_form_dismissed)
 
 func _on_consent_form_dismissed(uid : int, form_error_dictionary : Dictionary) -> void:
 	if uid == _uid:
 		var formError : FormError = FormError.create(form_error_dictionary) if not form_error_dictionary.is_empty() else null
 		_on_consent_form_dismissed_callback.call_deferred(formError)
+
 

--- a/addons/admob/src/ump/api/ConsentForm.gd
+++ b/addons/admob/src/ump/api/ConsentForm.gd
@@ -30,13 +30,16 @@ var _uid : int
 func _init(UID : int):
 	self._uid = UID
 
+var _on_consent_form_dismissed_callback
+
 func show(on_consent_form_dismissed := func(form_error : FormError) : pass) -> void:
 	if _plugin:
+		self._on_consent_form_dismissed_callback = on_consent_form_dismissed
 		_plugin.show(_uid)
+		_plugin.connect("on_consent_form_dismissed", _on_consent_form_dismissed, CONNECT_ONE_SHOT)
 
-		_plugin.connect("on_consent_form_dismissed", func(uid : int, form_error_dictionary : Dictionary) :
-			if uid == _uid:
-				var formError : FormError = FormError.create(form_error_dictionary) if not form_error_dictionary.is_empty() else null
-				on_consent_form_dismissed.call_deferred(formError)
-			, CONNECT_ONE_SHOT)
+func _on_consent_form_dismissed(uid : int, form_error_dictionary : Dictionary) -> void:
+	if uid == _uid:
+		var formError : FormError = FormError.create(form_error_dictionary) if not form_error_dictionary.is_empty() else null
+		_on_consent_form_dismissed_callback.call_deferred(formError)
 

--- a/addons/admob/src/ump/api/ConsentInformation.gd
+++ b/addons/admob/src/ump/api/ConsentInformation.gd
@@ -54,8 +54,11 @@ func update(consent_request : ConsentRequestParameters,
 		self._on_consent_info_updated_failure_callback = on_consent_info_updated_failure
 		_plugin.update(consent_request.convert_to_dictionary())
 		
-		_plugin.connect("on_consent_info_updated_success", _on_consent_info_updated_success, CONNECT_ONE_SHOT)
-		_plugin.connect("on_consent_info_updated_failure", _on_consent_info_updated_failure, CONNECT_ONE_SHOT)
+		if not _plugin.is_connected("on_consent_info_updated_success", _on_consent_info_updated_success):
+			_plugin.connect("on_consent_info_updated_success", _on_consent_info_updated_success)
+		if not _plugin.is_connected("on_consent_info_updated_failure", _on_consent_info_updated_failure):
+			_plugin.connect("on_consent_info_updated_failure", _on_consent_info_updated_failure)
+
 
 func reset():
 	if _plugin:

--- a/addons/admob/src/ump/api/ConsentInformation.gd
+++ b/addons/admob/src/ump/api/ConsentInformation.gd
@@ -42,20 +42,27 @@ func get_is_consent_form_available() -> bool:
 		return _plugin.get_is_consent_form_available()
 	return false
 
+var _on_consent_info_updated_success_callback
+var _on_consent_info_updated_failure_callback
+
 func update(consent_request : ConsentRequestParameters, 
 			on_consent_info_updated_success := func() : pass,
 			on_consent_info_updated_failure := func(form_error : FormError) : pass,
 			) -> void:
 	if _plugin:
+		self._on_consent_info_updated_success_callback = on_consent_info_updated_success
+		self._on_consent_info_updated_failure_callback = on_consent_info_updated_failure
 		_plugin.update(consent_request.convert_to_dictionary())
 		
-		_plugin.connect("on_consent_info_updated_success", func(): 
-			on_consent_info_updated_success.call_deferred()
-		, CONNECT_ONE_SHOT)
-		_plugin.connect("on_consent_info_updated_failure", func(form_error_dictionary : Dictionary): 
-			on_consent_info_updated_failure.call_deferred(FormError.create(form_error_dictionary))
-		, CONNECT_ONE_SHOT)
+		_plugin.connect("on_consent_info_updated_success", _on_consent_info_updated_success, CONNECT_ONE_SHOT)
+		_plugin.connect("on_consent_info_updated_failure", _on_consent_info_updated_failure, CONNECT_ONE_SHOT)
 
 func reset():
 	if _plugin:
 		_plugin.reset()
+
+func _on_consent_info_updated_success() -> void: 
+	_on_consent_info_updated_success_callback.call_deferred()
+
+func _on_consent_info_updated_failure(form_error_dictionary : Dictionary) -> void: 
+	_on_consent_info_updated_failure_callback.call_deferred(FormError.create(form_error_dictionary))

--- a/addons/admob/src/ump/api/UserMessagingPlatform.gd
+++ b/addons/admob/src/ump/api/UserMessagingPlatform.gd
@@ -27,16 +27,21 @@ static var _plugin := _get_plugin("PoingGodotAdMobUserMessagingPlatform")
 
 static var consent_information := ConsentInformation.new()
 
+static var _on_consent_form_load_success_listener_callback
+static var _on_consent_form_load_failure_listener_callback
+
 static func load_consent_form(
 		on_consent_form_load_success_listener := func(consent_form : ConsentForm) : pass,
 		on_consent_form_load_failure_listener := func(form_error : FormError) : pass) -> void:
 	if _plugin:
+		_on_consent_form_load_success_listener_callback = on_consent_form_load_success_listener
+		_on_consent_form_load_failure_listener_callback = on_consent_form_load_failure_listener
 		_plugin.load_consent_form()
-#
-		_plugin.connect("on_consent_form_load_success_listener", func(UID : int): 
-			on_consent_form_load_success_listener.call_deferred(ConsentForm.new(UID))
-		, CONNECT_ONE_SHOT)
+		_plugin.connect("on_consent_form_load_success_listener", _on_consent_form_load_success_listener, CONNECT_ONE_SHOT)
+		_plugin.connect("on_consent_form_load_failure_listener", _on_consent_form_load_failure_listener, CONNECT_ONE_SHOT)
 
-		_plugin.connect("on_consent_form_load_failure_listener", func(form_error_dictionary : Dictionary): 
-			on_consent_form_load_failure_listener.call_deferred(FormError.create(form_error_dictionary))
-		, CONNECT_ONE_SHOT)
+static func _on_consent_form_load_success_listener(UID : int) -> void: 
+	_on_consent_form_load_success_listener_callback.call_deferred(ConsentForm.new(UID))
+
+static func _on_consent_form_load_failure_listener(form_error_dictionary : Dictionary) -> void: 
+	_on_consent_form_load_failure_listener_callback.call_deferred(FormError.create(form_error_dictionary))


### PR DESCRIPTION
Replace lambdas to member functions, which fixes the crash when terminating.

Remove CONNECT_ONE_SHOT option, which will block callback when multiple loaders run concurrently.

Call reference() in load function to avoid it being freed in case the users may not keep a reference. And unreference when the callback complete.