### PR TITLE
fix(ios): guard converters against NSNull and non-string bundle values

### DIFF
--- a/platforms/ios/src/ads/converters/ObjectToGodotDictionary.h
+++ b/platforms/ios/src/ads/converters/ObjectToGodotDictionary.h
@@ -36,7 +36,7 @@
 + (Dictionary)convertGADAdapterStatusToDictionary:
     (GADAdapterStatus *)adapterStatus;
 + (Dictionary)convertGADAdSizeToDictionary:(GADAdSize)adSize;
-+ (Dictionary)convertNSErrorToDictionaryAsAdError:(NSError *)nsError;
++ (Dictionary)convertNSErrorToDictionaryAsAdError:(id)nsErrorObject;
 + (Dictionary)convertNSErrorToDictionaryAsLoadAdError:(NSError *)nsError;
 + (Dictionary)convertResponseInfoToDictionary:(GADResponseInfo *)responseInfo;
 + (Dictionary)convertLoadedAdapterResponseInfoToDictionary:
@@ -46,7 +46,7 @@
 + (Dictionary)convertBundleNSDictionaryToDictionary:
     (NSDictionary *)bundleNSDictionary;
 + (Dictionary)convertGADAdRewardToDictionary:(GADAdReward *)adReward;
-+ (Dictionary)convertNSErrorToDictionaryAsFormError:(NSError *)nsError;
++ (Dictionary)convertNSErrorToDictionaryAsFormError:(id)nsErrorObject;
 + (Dictionary)convertGADAdValueToDictionary:(GADAdValue *)adValue;
 
 @end

--- a/platforms/ios/src/ads/converters/ObjectToGodotDictionary.mm
+++ b/platforms/ios/src/ads/converters/ObjectToGodotDictionary.mm
@@ -58,17 +58,26 @@
   return dictionary;
 }
 
-+ (Dictionary)convertNSErrorToDictionaryAsAdError:(NSError *)nsError {
++ (Dictionary)convertNSErrorToDictionaryAsAdError:(id)nsErrorObject {
   Dictionary dictionary;
 
+  // `userInfo[NSUnderlyingErrorKey]` is not always an NSError. Ad SDKs put
+  // `[NSNull null]` there to mean "no underlying error", and NSNull is not nil,
+  // so a presence check passes it straight into this method — where `code` is
+  // sent to it and the app dies with `-[NSNull code]: unrecognized selector`.
+  // Seen in the field on banner load failures.
+  if (![nsErrorObject isKindOfClass:[NSError class]]) {
+    return dictionary;
+  }
+  NSError *nsError = (NSError *)nsErrorObject;
+
   dictionary["code"] = (int)nsError.code;
-  dictionary["domain"] = [nsError.domain UTF8String];
-  dictionary["message"] = [nsError.localizedDescription UTF8String];
-  dictionary["cause"] =
-      (nsError.userInfo[NSUnderlyingErrorKey])
-          ? [ObjectToGodotDictionary convertNSErrorToDictionaryAsAdError:
-                                         nsError.userInfo[NSUnderlyingErrorKey]]
-          : Dictionary();
+  dictionary["domain"] = nsError.domain ? [nsError.domain UTF8String] : "";
+  dictionary["message"] = nsError.localizedDescription
+                              ? [nsError.localizedDescription UTF8String]
+                              : "";
+  dictionary["cause"] = [ObjectToGodotDictionary
+      convertNSErrorToDictionaryAsAdError:nsError.userInfo[NSUnderlyingErrorKey]];
 
   return dictionary;
 }
@@ -154,9 +163,19 @@
     (NSDictionary *)bundleNSDictionary {
   Dictionary dictionary;
 
+  // Same lesson as the error converter: the values here are whatever the SDK
+  // put in the bundle. `extrasDictionary` and `adUnitMapping` routinely carry
+  // NSNumber, and NSNull stands in for a missing value — neither answers
+  // `UTF8String`. Anything that is not a string is described instead.
   for (NSString *key in [bundleNSDictionary allKeys]) {
-    NSString *value = [bundleNSDictionary objectForKey:key];
-    dictionary[key.UTF8String] = (value) ? [value UTF8String] : "";
+    id value = [bundleNSDictionary objectForKey:key];
+    const char *text = "";
+    if ([value isKindOfClass:[NSString class]]) {
+      text = [(NSString *)value UTF8String];
+    } else if (value && ![value isKindOfClass:[NSNull class]]) {
+      text = [[value description] UTF8String];
+    }
+    dictionary[key.UTF8String] = text ? text : "";
   }
 
   return dictionary;
@@ -171,11 +190,18 @@
   return dictionary;
 }
 
-+ (Dictionary)convertNSErrorToDictionaryAsFormError:(NSError *)nsError {
++ (Dictionary)convertNSErrorToDictionaryAsFormError:(id)nsErrorObject {
   Dictionary dictionary;
 
+  if (![nsErrorObject isKindOfClass:[NSError class]]) {
+    return dictionary;
+  }
+  NSError *nsError = (NSError *)nsErrorObject;
+
   dictionary["error_code"] = (int)nsError.code;
-  dictionary["message"] = [nsError.localizedDescription UTF8String];
+  dictionary["message"] = nsError.localizedDescription
+                              ? [nsError.localizedDescription UTF8String]
+                              : "";
 
   return dictionary;
 }


### PR DESCRIPTION
Fixes #501.

### The crash

`ObjectToGodotDictionary.convertNSErrorToDictionaryAsAdError:` recurses into `userInfo[NSUnderlyingErrorKey]` whenever that key is non-nil:

```objc
dictionary["cause"] =
    (nsError.userInfo[NSUnderlyingErrorKey])
        ? [ObjectToGodotDictionary convertNSErrorToDictionaryAsAdError:
                                       nsError.userInfo[NSUnderlyingErrorKey]]
        : Dictionary();
```

Ad SDKs store `[NSNull null]` under that key to mean "there is no underlying error". `NSNull` is not `nil`, so the presence check passes and the recursive call sends `code` to an `NSNull` instance:

```
-[NSNull code]: unrecognized selector sent to instance 0x1e4f0e5e8
*** Terminating app due to uncaught exception 'NSInvalidArgumentException'
```

`NSInvalidArgumentException` is uncaught, so the app terminates. We hit this in production on banner load failures with mediation adapters in the waterfall.

The secondary damage is worse than the crash line suggests: it happens **inside the failure callback**, before the plugin can emit the failure signal. The game never learns the ad failed, so a title that waits for `*_ad_failed_to_load` / `*_ad_failed_to_show_full_screen_content` before continuing sits on a dead screen. For a rewarded or interstitial that is a locked game.

### The fix

- `convertNSErrorToDictionaryAsAdError:` and `convertNSErrorToDictionaryAsFormError:` now take `id` and type-check with `isKindOfClass:[NSError class]`, returning an empty `Dictionary` for anything else. That covers `NSNull` and anything else a third-party adapter decides to put under that key. The recursion no longer needs its own presence check — the callee handles it.
- `domain` and `localizedDescription` are nil-guarded. `[nil UTF8String]` returns `NULL`, and building a Godot `String` from `NULL` is undefined behaviour.
- `convertBundleNSDictionaryToDictionary:` has the same class of bug from the other direction: it declares its values `NSString *`, but the bundles it is handed (`extrasDictionary`, `adUnitMapping` in `convertLoadedAdapterResponseInfoToDictionary:`) routinely carry `NSNumber`, and `NSNull` stands in for a missing value. Neither answers `UTF8String`. Non-strings are now passed through `description` instead.

Behaviour for well-formed `NSError`s is unchanged.

### Reproducing without an ad network

```objc
NSError *inner = nil;
NSError *outer = [NSError errorWithDomain:@"com.google.admob"
                                     code:1
                                 userInfo:@{NSUnderlyingErrorKey: [NSNull null]}];
[ObjectToGodotDictionary convertNSErrorToDictionaryAsAdError:outer];  // crashes on master
```

### Testing

Built with `./scripts/build.sh 4.6` and shipped in two live titles on iOS. The banner-failure crash has not recurred since.
