### PR TITLE
chore(ci): update Poing Reviewer to Poing AI action

### DIFF
--- a/.github/workflows/cron-sync-admob-dependencies.yml
+++ b/.github/workflows/cron-sync-admob-dependencies.yml
@@ -69,8 +69,8 @@ jobs:
           SUMMARY_TABLE: ${{ steps.sync.outputs.summary_table }}
         run: |
           BRANCH_NAME="deps/sync-admob-dependencies"
-          git config user.name "poing-reviewer[bot]"
-          git config user.email "296332247+poing-reviewer[bot]@users.noreply.github.com"
+          git config user.name "poing-ai[bot]"
+          git config user.email "296332247+poing-ai[bot]@users.noreply.github.com"
           
           git checkout -B "$BRANCH_NAME"
           git add -u platforms/android/src/ platforms/ios/src/

--- a/.github/workflows/poing-ai.yml
+++ b/.github/workflows/poing-ai.yml
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-name: Poing Reviewer
+name: Poing AI
 
 on:
   pull_request_target:
@@ -75,8 +75,8 @@ jobs:
           PR_NUMBER: ${{ inputs.number }}
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
-      - name: 3. Run Poing Reviewer
-        uses: poingstudios/poing-reviewer@master
+      - name: 3. Run Poing AI
+        uses: poingstudios/poing-ai@master
         with:
           mode: review
           number: ${{ inputs.number }}
@@ -103,8 +103,8 @@ jobs:
       - name: 2. Checkout Code
         uses: actions/checkout@v7
 
-      - name: 3. Run Poing Triage
-        uses: poingstudios/poing-reviewer@master
+      - name: 3. Run Poing AI
+        uses: poingstudios/poing-ai@master
         with:
           mode: triage
           number: ${{ inputs.number }}


### PR DESCRIPTION
### Summary
- Renamed `.github/workflows/poing-reviewer.yml` to `.github/workflows/poing-ai.yml`.
- Updated action references to `poingstudios/poing-ai@master`.
- Updated cron bot identity to `poing-ai[bot]`.