### PR TITLE
ci(poing-ai): enable autonomous issue worker and update triggers

### DIFF
--- a/.github/workflows/poing-ai.yml
+++ b/.github/workflows/poing-ai.yml
@@ -26,7 +26,7 @@ on:
   pull_request_target:
     types: [opened, ready_for_review]
   issues:
-    types: [opened]
+    types: [opened, labeled]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -82,7 +82,7 @@ jobs:
 
   triage:
     if: >
-      github.event_name == 'issues' ||
+      (github.event_name == 'issues' && github.event.action == 'opened') ||
       (github.event_name == 'pull_request_target' && github.event.action == 'opened') ||
       (github.event_name == 'workflow_dispatch' && inputs.mode == 'triage')
     runs-on: ubuntu-latest
@@ -112,11 +112,19 @@ jobs:
   fix:
     name: Auto-Fix
     if: >
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && (contains(github.event.comment.body, '/fix') || contains(github.event.comment.body, '@poing-ai fix') || contains(github.event.comment.body, '@poing-ai[bot] fix'))) ||
+      (github.event_name == 'issues' && (
+        contains(github.event.issue.labels.*.name, 'auto-fix') ||
+        contains(github.event.issue.labels.*.name, 'poing-work')
+      )) ||
+      (github.event_name == 'issue_comment' && (
+        (github.event.issue.pull_request && (contains(github.event.comment.body, '/fix') || contains(github.event.comment.body, '@poing-ai fix') || contains(github.event.comment.body, '@poing-ai[bot] fix'))) ||
+        (!github.event.issue.pull_request && (contains(github.event.comment.body, '/fix') || contains(github.event.comment.body, '/work') || contains(github.event.comment.body, '@poing-ai fix') || contains(github.event.comment.body, '@poing-ai work')))
+      )) ||
       (github.event_name == 'workflow_dispatch' && inputs.mode == 'fix')
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     steps:
       - name: 1. Generate App Token


### PR DESCRIPTION
## Summary
Enables the Autonomous Issue Worker introduced in `poing-ai` v1.2.0 and synchronizes workflow triggers and permissions with upstream.

### Changes
- **Issue triggers**: Added `labeled` event type (`issues: types: [opened, labeled]`).
- **Triage job**: Restricted to `opened` action (`github.event_name == 'issues' && github.event.action == 'opened'`) to prevent re-running triage on every label.
- **Fix job**:
  - Added issue comment triggers (`/fix`, `/work`) and label triggers (`auto-fix`, `poing-work`).
  - Added `issues: write` permission to allow posting comments and updates to issues.