### PR TITLE
ci: change signature of github-actions to poing-ai

### DIFF
--- a/.github/workflows/cd-deploy-docs.yml
+++ b/.github/workflows/cd-deploy-docs.yml
@@ -27,21 +27,35 @@ jobs:
       (github.event_name == 'release' && github.event.release.prerelease == false) ||
       (github.event_name == 'workflow_dispatch')
     steps:
-      - uses: actions/checkout@v7
+      - name: 1. Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
         with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        continue-on-error: true
+
+      - name: 2. Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           fetch-depth: 0 
+
       - uses: actions/setup-python@v7
         with:
           python-version: 3.x
+
       - uses: actions/cache@v6
         with:
           key: ${{ github.ref }}
           path: .cache
+
       - run: pip install mkdocs-material pillow cairosvg mike mkdocs-awesome-pages-plugin mkdocs-static-i18n
+
       - name: Configure Git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "poing-ai[bot]"
+          git config user.email "296332247+poing-ai[bot]@users.noreply.github.com"
       - name: Deploy documentation
         run: |
           DEPLOY_TARGET=""

--- a/.github/workflows/ci-pr-feedback.yml
+++ b/.github/workflows/ci-pr-feedback.yml
@@ -14,20 +14,29 @@ jobs:
       actions: read
 
     steps:
-    - name: Get PR number
+    - name: 1. Generate App Token
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      continue-on-error: true
+
+    - name: 2. Get PR number
       id: pr
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
       run: |
         PR_NUMBER=$(gh api \
           "repos/${{ github.repository }}/pulls?head=${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}&state=open" \
           --jq '.[0].number')
         echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
-    - name: Comment on success
+    - name: 3. Comment on success
       if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'skipped'
       uses: actions/github-script@v9
       with:
+        github-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         script: |
           const prNumber = parseInt('${{ steps.pr.outputs.number }}');
           if (!prNumber) return;
@@ -75,10 +84,11 @@ jobs:
           } else {
             await github.rest.issues.createComment({ issue_number: prNumber, owner: context.repo.owner, repo: context.repo.repo, body });
           }
-    - name: Comment on failure
+    - name: 4. Comment on failure
       if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled'
       uses: actions/github-script@v9
       with:
+        github-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         script: |
           const prNumber = parseInt('${{ steps.pr.outputs.number }}');
           if (!prNumber) return;


### PR DESCRIPTION
## Summary
Updates GitHub Actions workflows to use `poing-ai[bot]` signatures and tokens instead of default `github-actions[bot]`.

Closes #513

### Changes
- **`.github/workflows/cd-deploy-docs.yml`**:
  - Adds `actions/create-github-app-token@v3` to authenticate repository checkout and push with the Poing AI GitHub App.
  - Updates Git configuration user signature to `poing-ai[bot]` and `296332247+poing-ai[bot]@users.noreply.github.com`.
- **`.github/workflows/ci-pr-feedback.yml`**:
  - Adds `actions/create-github-app-token@v3` step.
  - Passes the App token to `actions/github-script@v9` and PR queries so check status comments are authored by `poing-ai[bot]`.