### PR TITLE
docs: sync native SDK versions and automate in cron workflow

### DIFF
--- a/.github/scripts/update_docs_dependencies.py
+++ b/.github/scripts/update_docs_dependencies.py
@@ -1,0 +1,150 @@
+# MIT License
+#
+# Copyright (c) 2026-present Poing Studios
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import List, Protocol
+
+
+@dataclass(frozen=True)
+class VersionRule:
+    pattern: str
+    replacement: str
+
+
+class VersionExtractor(Protocol):
+    def extract_rules(self, root_dir: Path) -> List[VersionRule]:
+        ...
+
+
+class AndroidAdsExtractor:
+    CONFIG_PATH = Path("platforms/android/src/ads/config/poing_godot_admob_ads.gd")
+    VERSION_REGEX = re.compile(
+        r"com\.google\.android\.libraries\.ads\.mobile\.sdk:ads-mobile-sdk:([0-9.]+)"
+    )
+
+    def extract_rules(self, root_dir: Path) -> List[VersionRule]:
+        file_path = root_dir / self.CONFIG_PATH
+        if not file_path.is_file():
+            return []
+
+        match = self.VERSION_REGEX.search(file_path.read_text(encoding="utf-8"))
+        if not match:
+            return []
+
+        version = match.group(1)
+        return [
+            VersionRule(
+                pattern=r"(com\.google\.android\.libraries\.ads\.mobile\.sdk:ads-mobile-sdk:)\d+\.\d+\.\d+",
+                replacement=rf"\g<1>{version}",
+            ),
+            VersionRule(
+                pattern=r"(com\.google\.android\.libraries\.ads\.mobile\.sdk/ads-mobile-sdk/)\d+\.\d+\.\d+",
+                replacement=rf"\g<1>{version}",
+            ),
+        ]
+
+
+class IOSAdsExtractor:
+    CONFIG_PATH = Path("platforms/ios/src/ads/config/poing_godot_admob_ads.gd")
+    PACKAGES = {
+        "swift-package-manager-google-mobile-ads": re.compile(
+            r'swift-package-manager-google-mobile-ads\.git",\s*"version":\s*"([^"]+)"'
+        ),
+        "swift-package-manager-google-user-messaging-platform": re.compile(
+            r'swift-package-manager-google-user-messaging-platform\.git",\s*"version":\s*"([^"]+)"'
+        ),
+    }
+
+    def extract_rules(self, root_dir: Path) -> List[VersionRule]:
+        file_path = root_dir / self.CONFIG_PATH
+        if not file_path.is_file():
+            return []
+
+        content = file_path.read_text(encoding="utf-8")
+        rules: List[VersionRule] = []
+
+        for repo_name, pattern in self.PACKAGES.items():
+            match = pattern.search(content)
+            if not match:
+                continue
+            version = match.group(1)
+            rules.append(
+                VersionRule(
+                    pattern=rf"({re.escape(repo_name)}/releases/tag/)\d+\.\d+\.\d+(\) [^`]+ `)\d+\.\d+\.\d+(`)",
+                    replacement=rf"\g<1>{version}\g<2>{version}\g<3>",
+                )
+            )
+
+        return rules
+
+
+class DocSyncService:
+    def __init__(self, root_dir: Path, extractors: List[VersionExtractor]):
+        self.root_dir = root_dir
+        self.extractors = extractors
+
+    def sync(self, doc_patterns: List[str]) -> bool:
+        rules: List[VersionRule] = []
+        for extractor in self.extractors:
+            rules.extend(extractor.extract_rules(self.root_dir))
+
+        if not rules:
+            return False
+
+        any_changed = False
+        target_files: List[Path] = []
+        for pattern in doc_patterns:
+            target_files.extend(self.root_dir.glob(pattern))
+
+        for file_path in sorted(set(target_files)):
+            if not file_path.is_file():
+                continue
+
+            content = file_path.read_text(encoding="utf-8")
+            updated = content
+
+            for rule in rules:
+                updated = re.sub(rule.pattern, rule.replacement, updated)
+
+            if updated != content:
+                file_path.write_text(updated, encoding="utf-8")
+                any_changed = True
+
+        return any_changed
+
+
+def main() -> None:
+    root_dir = Path(__file__).resolve().parent.parent.parent
+    service = DocSyncService(
+        root_dir=root_dir,
+        extractors=[
+            AndroidAdsExtractor(),
+            IOSAdsExtractor(),
+        ],
+    )
+    service.sync(["docs/index*.md"])
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/cron-sync-admob-dependencies.yml
+++ b/.github/workflows/cron-sync-admob-dependencies.yml
@@ -59,7 +59,11 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
 
-      - name: 4. Create or Update Pull Request
+      - name: 4. Update documentation SDK versions
+        if: steps.sync.outputs.has_updates == 'true'
+        run: python3 .github/scripts/update_docs_dependencies.py
+
+      - name: 5. Create or Update Pull Request
         if: steps.sync.outputs.has_updates == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}

--- a/docs/index.es.md
+++ b/docs/index.es.md
@@ -23,11 +23,11 @@ Este documento se basa en:
 
 === "Android"
 
-    * [`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.2.1`](https://mvnrepository.com/artifact/com.google.android.libraries.ads.mobile.sdk/ads-mobile-sdk/1.2.1) (Next-Gen SDK)
+    * [`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.4.0`](https://mvnrepository.com/artifact/com.google.android.libraries.ads.mobile.sdk/ads-mobile-sdk/1.4.0) (Next-Gen SDK)
 
 === "iOS"
 
-    * [`GoogleMobileAds`](https://github.com/googleads/swift-package-manager-google-mobile-ads/releases/tag/13.6.0) versión `13.6.0`
+    * [`GoogleMobileAds`](https://github.com/googleads/swift-package-manager-google-mobile-ads/releases/tag/13.9.0) versión `13.9.0`
     * [`GoogleUserMessagingPlatform`](https://github.com/googleads/swift-package-manager-google-user-messaging-platform/releases/tag/3.1.0) versión `3.1.0`
 
 ## Descargue el complemento Godot AdMob de Poing Studios

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -23,11 +23,11 @@ AdMob 插件を Godot プロジェクト（特に Godot v4.5 以降）に統合�
 
 === "Android"
 
-    * [`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.2.1`](https://mvnrepository.com/artifact/com.google.android.libraries.ads.mobile.sdk/ads-mobile-sdk/1.2.1) (Next-Gen SDK)
+    * [`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.4.0`](https://mvnrepository.com/artifact/com.google.android.libraries.ads.mobile.sdk/ads-mobile-sdk/1.4.0) (Next-Gen SDK)
 
 === "iOS"
 
-    * [`GoogleMobileAds`](https://github.com/googleads/swift-package-manager-google-mobile-ads/releases/tag/13.6.0) バージョン `13.6.0`
+    * [`GoogleMobileAds`](https://github.com/googleads/swift-package-manager-google-mobile-ads/releases/tag/13.9.0) バージョン `13.9.0`
     * [`GoogleUserMessagingPlatform`](https://github.com/googleads/swift-package-manager-google-user-messaging-platform/releases/tag/3.1.0) バージョン `3.1.0`
 
 ## Poing Studios からの Godot AdMob プラグインのダウンロード

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,11 +23,11 @@ This document is based on:
 
 === "Android"
 
-    * [`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.2.1`](https://mvnrepository.com/artifact/com.google.android.libraries.ads.mobile.sdk/ads-mobile-sdk/1.2.1) (Next-Gen SDK)
+    * [`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.4.0`](https://mvnrepository.com/artifact/com.google.android.libraries.ads.mobile.sdk/ads-mobile-sdk/1.4.0) (Next-Gen SDK)
 
 === "iOS"
 
-    * [`GoogleMobileAds`](https://github.com/googleads/swift-package-manager-google-mobile-ads/releases/tag/13.6.0) version `13.6.0`
+    * [`GoogleMobileAds`](https://github.com/googleads/swift-package-manager-google-mobile-ads/releases/tag/13.9.0) version `13.9.0`
     * [`GoogleUserMessagingPlatform`](https://github.com/googleads/swift-package-manager-google-user-messaging-platform/releases/tag/3.1.0) version `3.1.0`
 
 ## Download the Godot AdMob Plugin from Poing Studios

--- a/docs/index.pt-BR.md
+++ b/docs/index.pt-BR.md
@@ -23,11 +23,11 @@ Este documento é baseado em:
 
 === "Android"
 
-    * [`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.2.1`](https://mvnrepository.com/artifact/com.google.android.libraries.ads.mobile.sdk/ads-mobile-sdk/1.2.1) (Next-Gen SDK)
+    * [`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.4.0`](https://mvnrepository.com/artifact/com.google.android.libraries.ads.mobile.sdk/ads-mobile-sdk/1.4.0) (Next-Gen SDK)
 
 === "iOS"
 
-    * [`GoogleMobileAds`](https://github.com/googleads/swift-package-manager-google-mobile-ads/releases/tag/13.6.0) versão `13.6.0`
+    * [`GoogleMobileAds`](https://github.com/googleads/swift-package-manager-google-mobile-ads/releases/tag/13.9.0) versão `13.9.0`
     * [`GoogleUserMessagingPlatform`](https://github.com/googleads/swift-package-manager-google-user-messaging-platform/releases/tag/3.1.0) versão `3.1.0`
 
 ## Baixar o Plugin Godot AdMob da Poing Studios

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -23,11 +23,11 @@
 
 === "Android"
 
-    * [`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.2.1`](https://mvnrepository.com/artifact/com.google.android.libraries.ads.mobile.sdk/ads-mobile-sdk/1.2.1) (Next-Gen SDK)
+    * [`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.4.0`](https://mvnrepository.com/artifact/com.google.android.libraries.ads.mobile.sdk/ads-mobile-sdk/1.4.0) (Next-Gen SDK)
 
 === "iOS"
 
-    * [`GoogleMobileAds`](https://github.com/googleads/swift-package-manager-google-mobile-ads/releases/tag/13.6.0) 版本 `13.6.0`
+    * [`GoogleMobileAds`](https://github.com/googleads/swift-package-manager-google-mobile-ads/releases/tag/13.9.0) 版本 `13.9.0`
     * [`GoogleUserMessagingPlatform`](https://github.com/googleads/swift-package-manager-google-user-messaging-platform/releases/tag/3.1.0) 版本 `3.1.0`
 
 ## 从 Poing Studios 下载 Godot AdMob 插件


### PR DESCRIPTION
### Summary
- Corrected native Google Mobile Ads SDK versions in `docs/index*.md` across all 5 languages (English, Spanish, Japanese, Portuguese, Chinese) to match the current configurations:
  - Android Next-Gen SDK (`ads-mobile-sdk`): `1.2.1` -> `1.4.0`
  - iOS GoogleMobileAds: `13.6.0` -> `13.9.0`
  - iOS GoogleUserMessagingPlatform: `3.1.0`
- Added [update_docs_dependencies.py](file:///Volumes/Mac500GB/GitHub/Godot-AdMob-Editor-Plugin/.github/scripts/update_docs_dependencies.py) following SOLID principles to dynamically synchronize documentation from native GDScript config files without boilerplate.
- Integrated the update script into [cron-sync-admob-dependencies.yml](file:///Volumes/Mac500GB/GitHub/Godot-AdMob-Editor-Plugin/.github/workflows/cron-sync-admob-dependencies.yml) so future dependency syncs automatically update documentation.

Closes #500