### PR TITLE
docs(mediation): fix broken apply_all_networks image url

### DIFF
--- a/docs/mediate/get_started.es.md
+++ b/docs/mediate/get_started.es.md
@@ -92,7 +92,7 @@ Al utilizar anuncios de banner en la mediación de AdMob, es esencial inhabilita
 
 ## Mediación de anuncios bonificados
 Le recomendamos encarecidamente que personalice todos los valores de recompensa predeterminados configurándolos en la interfaz de usuario de AdMob. Para lograr esto, seleccione la opción **Aplicar a todas las redes en grupos de mediación** para garantizar que la recompensa permanezca uniforme en todas las redes. Tenga en cuenta que es posible que determinadas redes publicitarias no proporcionen un valor o tipo de recompensa. Al anular el valor de la recompensa, garantiza una recompensa constante, independientemente de la red publicitaria responsable de publicar el anuncio.
-![apply_all_networks](https://developers.google.com/static/admob/images/mediation/admob_apply_all_networks.png)
+![apply_all_networks](https://i.imgur.com/QR0jPx7.png)
 
 Para obtener más información sobre cómo configurar valores de recompensa en la interfaz de usuario de AdMob, consulte crear un bloque de anuncios recompensados.
 

--- a/docs/mediate/get_started.ja.md
+++ b/docs/mediate/get_started.ja.md
@@ -93,7 +93,7 @@ AdMob メディエーションでバナー広告を使用する場合、メデ�
 
 ## リワード広告のメディエーション
 AdMob UI 内で報酬値を設定して、すべてのデフォルトの報酬値をカスタマイズすることを強くお勧めします。これを実現するには、**[メディエーション グループのすべてのネットワークに適用]** オプションを選択して、すべてのネットワークで報酬が一律になるようにします。一部の広告ネットワークでは、報酬値またはタイプが提供されない場合があることに注意してください。報酬値を上書きすることで、広告配信を担当する広告ネットワークに関係なく、一貫した報酬が提供されることが保証されます。
-![apply_all_networks](https://developers.google.com/static/admob/images/mediation/admob_apply_all_networks.png)
+![apply_all_networks](https://i.imgur.com/QR0jPx7.png)
 
 AdMob UI での報酬値の設定に関する詳細については、[リワード広告ユニットの作成](https://support.google.com/admob/answer/7311747)のドキュメントを参照してください。
 

--- a/docs/mediate/get_started.md
+++ b/docs/mediate/get_started.md
@@ -93,7 +93,7 @@ When utilizing banner ads in AdMob mediation, it's essential to disable refresh 
 
 ## Rewarded ads mediation
 We strongly advise you to customize all default reward values by configuring reward values within the AdMob UI. To accomplish this, select the **Apply to all networks in Mediation groups** option to ensure that the reward remains uniform across all networks. Keep in mind that certain ad networks may not provide a reward value or type. By overriding the reward value, you guarantee a consistent reward, regardless of the ad network responsible for serving the ad.
-![apply_all_networks](https://developers.google.com/static/admob/images/mediation/admob_apply_all_networks.png)
+![apply_all_networks](https://i.imgur.com/QR0jPx7.png)
 
 For more information on setting reward values in the AdMob UI, refer to create a rewarded ad unit.
 

--- a/docs/mediate/get_started.pt-BR.md
+++ b/docs/mediate/get_started.pt-BR.md
@@ -93,7 +93,7 @@ Ao utilizar anúncios de banner na mediação do AdMob, é essencial desativar a
 
 ## Mediação de anúncios premiados
 Recomendamos fortemente que você personalize todos os valores de recompensa padrão configurando os valores de recompensa na interface do AdMob. Para isso, selecione a opção **Aplicar a todas as redes nos grupos de mediação** para garantir que a recompensa permaneça uniforme em todas as redes. Lembre-se de que certas redes de anúncios podem não fornecer um valor ou tipo de recompensa. Ao substituir o valor da recompensa, você garante uma recompensa consistente, independentemente da rede de anúncios responsável por veicular o anúncio.
-![apply_all_networks](https://developers.google.com/static/admob/images/mediation/admob_apply_all_networks.png)
+![apply_all_networks](https://i.imgur.com/QR0jPx7.png)
 
 Para detalhes completos sobre como definir valores de recompensa na interface do AdMob, consulte a documentação [Criar um Bloco de Anúncios Premiados](https://support.google.com/admob/answer/7311747).
 

--- a/docs/mediate/get_started.zh.md
+++ b/docs/mediate/get_started.zh.md
@@ -92,7 +92,7 @@ AdMob 中介（Mediation）是一项极具价值的功能，允许您向您的�
 
 ## 激励广告中介
 我们强烈建议您通过在 AdMob UI 中配置奖励值来自定义所有默认奖励值。为此，请选择**应用到中介组中的所有网络**选项，以确保奖励在所有网络中保持一致。请记住，某些广告网络可能不提供奖励值或类型。通过覆盖奖励值，无论由哪个广告网络负责投放该广告，您都能保证获得一致的奖励。
-![apply_all_networks](https://developers.google.com/static/admob/images/mediation/admob_apply_all_networks.png)
+![apply_all_networks](https://i.imgur.com/QR0jPx7.png)
 
 有关在 AdMob UI 中设置奖励值的更多信息，请参阅创建激励广告单元。
 


### PR DESCRIPTION
### Summary
Replaced the broken 404 Google image URL with the direct Imgur image URL across all documentation languages (`docs/mediate/get_started*.md`):
- English (`docs/mediate/get_started.md`)
- Spanish (`docs/mediate/get_started.es.md`)
- Japanese (`docs/mediate/get_started.ja.md`)
- Portuguese (`docs/mediate/get_started.pt-BR.md`)
- Chinese (`docs/mediate/get_started.zh.md`)

Closes #471