### PR TITLE
docs(mediation): align choose ad sources table with official Google documentation

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: dorny/paths-filter@v4
       id: filter
       with:
+        predicate-quantifier: 'some-with-excludes'
         filters: |
           code:
             - 'platforms/**'

--- a/docs/mediate/choose_networks.es.md
+++ b/docs/mediate/choose_networks.es.md
@@ -1,25 +1,561 @@
 # Elegir fuentes de anuncios
 
-Una vez que hayas configurado la Mediación de AdMob, puedes elegir qué fuentes de anuncios utilizar. Las fuentes de anuncios son redes de anuncios de terceros que pueden publicar anuncios a través de la Mediación de AdMob.
+La mediación de AdMob admite varias fuentes de anuncios, que admiten integraciones tanto para métodos de puja (bidding) como de cascada (waterfall). Haz clic en una fuente de anuncios para ver las instrucciones de integración específicas de esa red.
 
-## Fuentes de anuncios admitidas
+<table class="admob-matrix-table" id="network-details">
+  <thead>
+    <tr>
+      <th style="width: 17%;">Fuente de anuncios</th>
+      <th style="width: 8%;">App<br>Open</th>
+      <th style="width: 8%;">Banner</th>
+      <th style="width: 10.5%;">Interstitial</th>
+      <th style="width: 9%;">Rewarded</th>
+      <th style="width: 11%;">Rewarded<br>Interstitial</th>
+      <th style="width: 8%;">Native</th>
+      <th style="width: 8.5%;">Bidding</th>
+      <th style="width: 20%;">Soporte de optimización<br>de fuentes de anuncios</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="table-section-row">
+      <th colspan="9">Código abierto y versionado: se requieren SDK de terceros</th>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/applovin.md">AppLovin</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/bidmachine.md">BidMachine</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Ninguno</td>
+    </tr>
+    <tr>
+      <td><a href="https://developers.google.com/admob/ios/mediation/bigo" target="_blank">BIGO Ads SDK</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Ninguno</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/chartboost.md">Chartboost</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/dtexchange.md">DT Exchange</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/imobile.md">i-mobile</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td>Solo Japón</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/inmobi.md">InMobi</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/ironsource.md">ironSource Ads</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/vungle.md">Liftoff Monetize</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/line.md">LY Ads Network</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/maio.md">maio</a></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Solo Japón</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/meta.md">Meta Audience Network</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/mintegral.md">Mintegral</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/moloco.md">Moloco</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/mytarget.md">myTarget</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/pangle.md">Pangle</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/pubmatic.md">PubMatic OpenWrap</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/unity_ads.md">Unity Ads</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr class="table-section-row">
+      <th colspan="9">Código cerrado: se requieren SDK de terceros</th>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/vpon.md">Vpon</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Ninguno</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/zucks.md">Zucks</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Específico del país</td>
+    </tr>
+    <tr class="table-section-row">
+      <th colspan="9">No se requieren SDK de terceros</th>
+    </tr>
+    <tr>
+      <td>Ad Generation</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Bidease</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Chocolate Platform</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Equativ (formerly Smart Adserver)</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Fluct</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Improve Digital</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Index Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>InMobi Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Magnite DV+</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Media.net</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>MobFox</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Nativo</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Nexxen (previously UnrulyX)</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>OneTag Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>OpenX</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>PubMatic</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Rise</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Sharethrough</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Smaato</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Sonobi</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>TripleLift</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Verve Group</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>Yieldmo</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+    <tr>
+      <td>YieldOne</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Solo puja</td>
+    </tr>
+  </tbody>
+</table>
 
-La Mediación de AdMob admite una amplia gama de fuentes de anuncios. Consulta la lista de [fuentes de anuncios integradas](integrate_partner_networks/applovin.md) para obtener detalles sobre cada red.
+<p class="table-footnotes">
+  <span id="bidding-footnote"><sup>1</sup></span> La integración de ofertas (bidding) está en versión beta.<br>
+  <span id="format-beta-sdkb-footnote"><sup>2</sup></span> Este formato está en versión beta (SDK bidding).
+</p>
 
-## Elegir fuentes de anuncios
+!!! note "Nota"
+    Las fuentes de anuncios están ordenadas alfabéticamente.
 
-Al elegir fuentes de anuncios, considera:
+## Adaptadores de código abierto y versionados
 
-- **Tasa de relleno (Fill rate)**: Qué tan bien la fuente de anuncios llena las solicitudes de anuncios en tus regiones objetivo.
-- **eCPM**: El costo efectivo por mil (mil impresiones) que proporciona la fuente de anuncios.
-- **Formatos de anuncios**: Qué formatos de anuncios admite la fuente de anuncios.
-- **Complejidad de la integración**: Qué tan fácil es integrar la fuente de anuncios.
+Si un adaptador está etiquetado como "Código abierto y versionado" en la tabla anterior, significa que el código fuente del adaptador es de código abierto en el repositorio de GitHub de Google ([Android](https://github.com/googleads/googleads-mobile-android-mediation){:target="_blank"} o [iOS](https://github.com/googleads/googleads-mobile-ios-mediation){:target="_blank"}), lo que te permite depurar problemas por tu cuenta si lo deseas.
 
-## Subasta (Bidding) vs Cascada (Waterfall)
+Cada adaptador se compila para una versión específica del SDK de la red publicitaria de terceros. Sigue la guía de integración del socio específico para más detalles.
 
-La Mediación de AdMob admite dos métodos de integración:
+### Versionado de adaptadores
 
-- **Subasta (Bidding)**: Las fuentes de anuncios compiten en tiempo real por tu inventario de anuncios. Este es el método recomendado.
-- **Cascada (Waterfall)**: Las fuentes de anuncios se priorizan en un orden secuencial.
+Los adaptadores de Godot siguen un esquema de versiones `<major>.<minor>.<patch>` que modela las dependencias subyacentes de los SDK de Android e iOS para esa red publicitaria. Si la dependencia de Android o iOS recibe una actualización de versión mayor o menor, el adaptador de Godot también recibe la correspondiente actualización. Todas las demás versiones reciben un incremento de versión de parche.
 
-Para obtener más información sobre las subastas, consulta [Solucionar problemas de subasta](troubleshoot_bidding.md).
+!!! important "Importante"
+    Asegúrate de desactivar la actualización automática (refresh) en la interfaz de todas las redes de terceros para los bloques de anuncios de banner usados en la mediación de AdMob. Esto evita una actualización doble, ya que AdMob también actualiza según la frecuencia de tu bloque.
+
+## Optimización de fuentes de anuncios
+
+Cuando configuras varias redes publicitarias para la mediación, debes especificar el orden para solicitarlas configurando sus CPM respectivos. Esto puede ser difícil de administrar, ya que el rendimiento cambia con el tiempo.
+
+La [optimización de fuentes de anuncios](https://support.google.com/admob/answer/7388022){:target="_blank"} es una función que te permite generar el CPM más alto automatizando el proceso de ordenación de la cadena de mediación para maximizar los ingresos.
+
+La [tabla de redes de mediación](#network-details) anterior utiliza los siguientes valores para el soporte de optimización:
+
+| Soporte de optimización de fuentes de anuncios | Qué significa |
+| :--- | :--- |
+| `Solo puja` | La red publicitaria solo participa en pujas. La optimización de fuentes de anuncios no se aplica. |
+| `Específico del país` | Los valores de eCPM se actualizan automáticamente en tu nombre país por país. Este es el tipo óptimo de optimización. |
+| `Ninguno` | Debes configurar manualmente un valor de eCPM para esa red publicitaria. |
+
+Haz clic en la guía de una red publicitaria específica para obtener detalles sobre cómo configurar la optimización para esa red.
+
+!!! note "Nota"
+    Solo las redes publicitarias etiquetadas como **Código abierto y versionado** tienen instrucciones específicas para configurar la optimización.
+
+## Eventos personalizados
+
+Si buscas una red publicitaria y no la ves en la lista anterior, puedes usar eventos personalizados para escribir tu propia integración. Consulta la [guía de eventos personalizados de Google](https://developers.google.com/admob/android/mediation/custom-events){:target="_blank"} para obtener más detalles.
+
+!!! note "Nota"
+    Los eventos personalizados no tienen soporte para optimización de fuentes de anuncios ni para pujas (bidding).

--- a/docs/mediate/choose_networks.ja.md
+++ b/docs/mediate/choose_networks.ja.md
@@ -1,25 +1,561 @@
 # 広告ソースの選択
 
-AdMob メディエーションを設定すると、使用する広告ソースを選択できます。広告ソースとは、AdMob メディエーションを通じて広告を配信できるサードパーティの広告ネットワークです。
+AdMob メディエーションは、入札 (Bidding) とウォーターフォール (Waterfall) の両方の統合方法に対応する複数の広告ソースをサポートしています。広告ソースをクリックすると、その広告ソース専用の統合手順が表示されます。
 
-## サポートされている広告ソース
+<table class="admob-matrix-table" id="network-details">
+  <thead>
+    <tr>
+      <th style="width: 17%;">広告ソース</th>
+      <th style="width: 8%;">App<br>Open</th>
+      <th style="width: 8%;">Banner</th>
+      <th style="width: 10.5%;">Interstitial</th>
+      <th style="width: 9%;">Rewarded</th>
+      <th style="width: 11%;">Rewarded<br>Interstitial</th>
+      <th style="width: 8%;">Native</th>
+      <th style="width: 8.5%;">Bidding</th>
+      <th style="width: 20%;">広告ソースの最適化<br>サポート</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="table-section-row">
+      <th colspan="9">オープンソースでバージョン管理済み - サードパーティ SDK が必要</th>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/applovin.md">AppLovin</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/bidmachine.md">BidMachine</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>なし</td>
+    </tr>
+    <tr>
+      <td><a href="https://developers.google.com/admob/ios/mediation/bigo" target="_blank">BIGO Ads SDK</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>なし</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/chartboost.md">Chartboost</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/dtexchange.md">DT Exchange</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/imobile.md">i-mobile</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td>日本のみ</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/inmobi.md">InMobi</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/ironsource.md">ironSource Ads</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/vungle.md">Liftoff Monetize</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/line.md">LY Ads Network</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/maio.md">maio</a></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>日本のみ</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/meta.md">Meta Audience Network</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/mintegral.md">Mintegral</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/moloco.md">Moloco</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/mytarget.md">myTarget</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/pangle.md">Pangle</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/pubmatic.md">PubMatic OpenWrap</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td><span class="table-check">✓</span></td>
+      <td>国固有</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/unity_ads.md">Unity Ads</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>国固有</td>
+    </tr>
+    <tr class="table-section-row">
+      <th colspan="9">非オープンソース - サードパーティ SDK が必要</th>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/vpon.md">Vpon</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>なし</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/zucks.md">Zucks</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>国固有</td>
+    </tr>
+    <tr class="table-section-row">
+      <th colspan="9">サードパーティ SDK は不要</th>
+    </tr>
+    <tr>
+      <td>Ad Generation</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Bidease</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Chocolate Platform</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Equativ (formerly Smart Adserver)</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Fluct</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Improve Digital</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Index Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>InMobi Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Magnite DV+</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Media.net</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>MobFox</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Nativo</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Nexxen (previously UnrulyX)</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>OneTag Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>OpenX</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>PubMatic</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Rise</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Sharethrough</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Smaato</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Sonobi</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>TripleLift</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Verve Group</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>Yieldmo</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+    <tr>
+      <td>YieldOne</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>入札のみ</td>
+    </tr>
+  </tbody>
+</table>
 
-AdMob メディエーションは、幅広い広告ソースをサポートしています。各ネットワークの詳細については、[統合された広告ソース](integrate_partner_networks/applovin.md)のリストを参照してください。
+<p class="table-footnotes">
+  <span id="bidding-footnote"><sup>1</sup></span> 入札 (Bidding) の統合はベータ版です。<br>
+  <span id="format-beta-sdkb-footnote"><sup>2</sup></span> このフォーマットはベータ版です (SDK 入札)。
+</p>
 
-## 広告ソースの選択
+!!! note "注"
+    広告ソースはアルファベット順に並んでいます。
 
-広告ソースを選択する際は、以下を考慮してください。
+## オープンソースでバージョン管理されたアダプター
 
-- **充填率 (Fill rate)**: 対象地域での広告リクエストに対する広告ソースの充填率
-- **eCPM**: 広告ソースが提供するインプレッション 1,000 回あたりの有効単価
-- **広告フォーマット**: 広告ソースがサポートしている広告フォーマット
-- **統合の複雑さ**: 広告ソースの統合の容易さ
+上記テーブルで「オープンソースでバージョン管理済み」と記載されているアダプターは、Google の GitHub リポジトリ（[Android](https://github.com/googleads/googleads-mobile-android-mediation){:target="_blank"} または [iOS](https://github.com/googleads/googleads-mobile-ios-mediation){:target="_blank"}）でソースコードが公開されており、必要に応じてご自身で問題をデバッグできます。
 
-## 入札 (Bidding) vs ウォーターフォール (Waterfall)
+各アダプターは、サードパーティ広告ネットワーク SDK の特定バージョン向けにビルドされています。詳細は各パートナーの統合ガイドをご確認ください。
 
-AdMob メディエーションは、2 つの統合方法をサポートしています。
+### アダプターのバージョニング
 
-- **入札 (Bidding)**: 広告ソースがリアルタイムで広告枠を競い合います。これが推奨される方法です。
-- **ウォーターフォール (Waterfall)**: 広告ソースが順次優先順位付けされます。
+Godot アダプターは、該当広告ネットワークの基盤となる Android および iOS SDK 依存関係をモデルにした `<major>.<minor>.<patch>` バージョニング規則に従います。Android または iOS の依存関係がメジャーまたはマイナーアップデートされた場合、Godot アダプターも対応してアップデートされます。その他のリリースはパッチバージョンが上がります。
 
-入札の詳細については、[入札のトラブルシューティング](troubleshoot_bidding.md)を参照してください。
+!!! important "重要"
+    AdMob メディエーションで使用するバナー広告ユニットについては、すべてのサードパーティ広告ネットワークの管理画面で自動更新（リフレッシュ）を必ず無効にしてください。AdMob 側でもバナーのリフレッシュレートに基づいて更新が実行されるため、二重更新を防ぐことができます。
+
+## 広告ソースの最適化
+
+メディエーション用に複数の広告ネットワークを設定する場合、各ネットワークの CPM を設定してリクエスト順序を指定する必要があります。広告ネットワークの掲載結果は時間とともに変化するため、手動管理が難しくなることがあります。
+
+[広告ソースの最適化](https://support.google.com/admob/answer/7388022){:target="_blank"} は、メディエーション チェーンの順序付けプロセスを自動化して収益を最大化し、チェーン内の広告ネットワークから最大の CPM を生み出す機能です。
+
+上記の[メディエーション ネットワーク テーブル](#network-details)では、最適化サポートに以下の値を使用しています。
+
+| 広告ソースの最適化サポート | 意味 |
+| :--- | :--- |
+| `入札のみ` | 広告ネットワークは入札のみに参加します。広告ソースの最適化は適用されません。 |
+| `国固有` | 国ごとに eCPM 値が自動的に更新されます。これは最も最適な最適化タイプです。 |
+| `なし` | その広告ネットワークの eCPM 値を手動で設定する必要があります。 |
+
+広告ソースの最適化を設定する手順については、各広告ネットワークのガイドをご覧ください。
+
+!!! note "注"
+    **オープンソースでバージョン管理済み**の広告ネットワークのみ、広告ソースの最適化を設定するための手順が用意されています。
+
+## カスタム イベント
+
+使用したい広告ネットワークが上記リストに見当たらない場合は、カスタム イベントを使用してその広告ネットワーク独自の統合を作成できます。詳細は Google の[カスタム イベント ガイド](https://developers.google.com/admob/android/mediation/custom-events){:target="_blank"}をご確認ください。
+
+!!! note "注"
+    カスタム イベントには、広告ソースの最適化や入札 (Bidding) のサポートはありません。

--- a/docs/mediate/choose_networks.md
+++ b/docs/mediate/choose_networks.md
@@ -1,25 +1,561 @@
 # Choose ad sources
 
-Once you've set up AdMob Mediation, you can choose which ad sources to use. Ad sources are third-party ad networks that can serve ads through AdMob Mediation.
+AdMob Mediation supports several ad sources, which accommodate integrations for both bidding and waterfall methods. Click an ad source for integration instructions specific to that ad source.
 
-## Supported ad sources
+<table class="admob-matrix-table" id="network-details">
+  <thead>
+    <tr>
+      <th style="width: 17%;">Ad source</th>
+      <th style="width: 8%;">App<br>Open</th>
+      <th style="width: 8%;">Banner</th>
+      <th style="width: 10.5%;">Interstitial</th>
+      <th style="width: 9%;">Rewarded</th>
+      <th style="width: 11%;">Rewarded<br>Interstitial</th>
+      <th style="width: 8%;">Native</th>
+      <th style="width: 8.5%;">Bidding</th>
+      <th style="width: 20%;">Ad source optimization<br>support</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="table-section-row">
+      <th colspan="9">Open source and versioned - third party SDKs required</th>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/applovin.md">AppLovin</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/bidmachine.md">BidMachine</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td><a href="https://developers.google.com/admob/ios/mediation/bigo" target="_blank">BIGO Ads SDK</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/chartboost.md">Chartboost</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/dtexchange.md">DT Exchange</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/imobile.md">i-mobile</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td>Japan only</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/inmobi.md">InMobi</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/ironsource.md">ironSource Ads</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/vungle.md">Liftoff Monetize</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/line.md">LY Ads Network</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/maio.md">maio</a></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Japan only</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/meta.md">Meta Audience Network</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/mintegral.md">Mintegral</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/moloco.md">Moloco</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/mytarget.md">myTarget</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/pangle.md">Pangle</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/pubmatic.md">PubMatic OpenWrap</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/unity_ads.md">Unity Ads</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr class="table-section-row">
+      <th colspan="9">Non-open source - third party SDKs required</th>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/vpon.md">Vpon</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/zucks.md">Zucks</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Country-specific</td>
+    </tr>
+    <tr class="table-section-row">
+      <th colspan="9">No third-party SDKs required</th>
+    </tr>
+    <tr>
+      <td>Ad Generation</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Bidease</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Chocolate Platform</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Equativ (formerly Smart Adserver)</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Fluct</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Improve Digital</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Index Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>InMobi Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Magnite DV+</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Media.net</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>MobFox</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Nativo</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Nexxen (previously UnrulyX)</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>OneTag Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>OpenX</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>PubMatic</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Rise</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Sharethrough</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Smaato</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Sonobi</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>TripleLift</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Verve Group</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>Yieldmo</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+    <tr>
+      <td>YieldOne</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Bidding only</td>
+    </tr>
+  </tbody>
+</table>
 
-AdMob Mediation supports a wide range of ad sources. See the list of [integrated ad sources](integrate_partner_networks/applovin.md) for details on each network.
+<p class="table-footnotes">
+  <span id="bidding-footnote"><sup>1</sup></span> Bidding integration is in beta.<br>
+  <span id="format-beta-sdkb-footnote"><sup>2</sup></span> This format is in beta (SDK bidding).
+</p>
 
-## Choosing ad sources
+!!! note "Note"
+    Ad sources are ordered alphabetically.
 
-When choosing ad sources, consider:
+## Open source and versioned adapters
 
-- **Fill rate**: How well the ad source fills ad requests in your target regions
-- **eCPM**: The effective cost per mille (thousand impressions) the ad source provides
-- **Ad formats**: Which ad formats the ad source supports
-- **Integration complexity**: How easy it is to integrate the ad source
+If an adapter is labeled with "Open source and versioned" in the previous table, it means the adapter source code is open-sourced in Google's GitHub repository ([Android](https://github.com/googleads/googleads-mobile-android-mediation){:target="_blank"} or [iOS](https://github.com/googleads/googleads-mobile-ios-mediation){:target="_blank"}), enabling you to debug issues yourself should you choose to do so.
 
-## Bidding vs Waterfall
+Each adapter is built against a specific version of the third-party ad network SDK. Follow the specific partner's integration guide for more details.
 
-AdMob Mediation supports two integration methods:
+### Adapter versioning
 
-- **Bidding**: Ad sources compete in real-time for your ad inventory. This is the recommended method.
-- **Waterfall**: Ad sources are prioritized in a sequential order.
+Godot adapters follow a `<major>.<minor>.<patch>` versioning scheme that models the underlying Android and iOS SDK dependencies for that ad network. If either the Android or iOS dependency gets a major or minor version bump, the Godot adapter also gets a corresponding version bump. All other releases get a patch version bump.
 
-For more information on bidding, see [Troubleshoot bidding](troubleshoot_bidding.md).
+!!! important "Important"
+    Make sure to disable refresh in all third-party ad networks UI for banner ad units used in AdMob Mediation. This prevents a double refresh since AdMob also triggers a refresh based on your banner ad unit's refresh rate.
+
+## Ad source optimization
+
+When you configure multiple ad networks for mediation, you have to specify what order to request these networks by setting their respective CPM. This can be difficult to manage, since ad network performance changes over time.
+
+[Ad source optimization](https://support.google.com/admob/answer/7388022){:target="_blank"} is a feature that lets you generate the highest CPM from the ad networks in your mediation chain by automating the process of ordering the mediation chain to maximize revenue.
+
+The previous [mediation networks table](#network-details) uses the following values for ad source optimization support:
+
+| Ad source optimization support | What it means |
+| :--- | :--- |
+| `Bidding only` | The ad network only participates in bidding. Ad source optimization is not applicable. |
+| `Country-specific` | eCPM values are automatically updated on your behalf on a per-country basis. This is the optimal type of optimization. |
+| `None` | You must manually configure an eCPM value for that ad network. |
+
+Click a specific ad network's guide for details on how to configure ad source optimization for that network.
+
+!!! note "Note"
+    Only ad networks that are **Open source and versioned** have specific instructions for setting up ad source optimization on that network.
+
+## Custom events
+
+If you're looking for an ad network and don't see it on the list earlier, you can use custom events to write your own integration with that ad network. See Google's [custom events guide](https://developers.google.com/admob/android/mediation/custom-events){:target="_blank"} for more details on how to create a custom event.
+
+!!! note "Note"
+    Custom events don't have ad source optimization or bidding support.

--- a/docs/mediate/choose_networks.pt-BR.md
+++ b/docs/mediate/choose_networks.pt-BR.md
@@ -1,25 +1,561 @@
 # Escolher fontes de anúncios
 
-Depois de configurar a Mediação do AdMob, você pode escolher quais fontes de anúncios usar. As fontes de anúncios são redes de anúncios de terceiros que podem veicular anúncios por meio da Mediação do AdMob.
+A Mediação do AdMob suporta várias fontes de anúncios, que acomodam integrações para métodos de leilão (bidding) e cascata (waterfall). Clique em uma fonte de anúncios para ver as instruções de integração específicas para essa rede.
 
-## Fontes de anúncios suportadas
+<table class="admob-matrix-table" id="network-details">
+  <thead>
+    <tr>
+      <th style="width: 17%;">Fonte de anúncios</th>
+      <th style="width: 8%;">App<br>Open</th>
+      <th style="width: 8%;">Banner</th>
+      <th style="width: 10.5%;">Interstitial</th>
+      <th style="width: 9%;">Rewarded</th>
+      <th style="width: 11%;">Rewarded<br>Interstitial</th>
+      <th style="width: 8%;">Native</th>
+      <th style="width: 8.5%;">Bidding</th>
+      <th style="width: 20%;">Suporte de otimização<br>de fontes de anúncios</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="table-section-row">
+      <th colspan="9">Código aberto e versionado - SDKs de terceiros necessários</th>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/applovin.md">AppLovin</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/bidmachine.md">BidMachine</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Nenhum</td>
+    </tr>
+    <tr>
+      <td><a href="https://developers.google.com/admob/ios/mediation/bigo" target="_blank">BIGO Ads SDK</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Nenhum</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/chartboost.md">Chartboost</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/dtexchange.md">DT Exchange</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/imobile.md">i-mobile</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td>Apenas Japão</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/inmobi.md">InMobi</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/ironsource.md">ironSource Ads</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/vungle.md">Liftoff Monetize</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/line.md">LY Ads Network</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/maio.md">maio</a></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Apenas Japão</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/meta.md">Meta Audience Network</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/mintegral.md">Mintegral</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/moloco.md">Moloco</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/mytarget.md">myTarget</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/pangle.md">Pangle</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/pubmatic.md">PubMatic OpenWrap</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/unity_ads.md">Unity Ads</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr class="table-section-row">
+      <th colspan="9">Código fechado - SDKs de terceiros necessários</th>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/vpon.md">Vpon</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Nenhum</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/zucks.md">Zucks</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>Específico por país</td>
+    </tr>
+    <tr class="table-section-row">
+      <th colspan="9">Nenhum SDK de terceiros necessário</th>
+    </tr>
+    <tr>
+      <td>Ad Generation</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Bidease</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Chocolate Platform</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Equativ (formerly Smart Adserver)</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Fluct</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Improve Digital</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Index Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>InMobi Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Magnite DV+</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Media.net</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>MobFox</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Nativo</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Nexxen (previously UnrulyX)</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>OneTag Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>OpenX</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>PubMatic</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Rise</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Sharethrough</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Smaato</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Sonobi</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>TripleLift</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Verve Group</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>Yieldmo</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+    <tr>
+      <td>YieldOne</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>Apenas leilão</td>
+    </tr>
+  </tbody>
+</table>
 
-A Mediação do AdMob suporta uma ampla variedade de fontes de anúncios. Consulte a lista de [fontes de anúncios integradas](integrate_partner_networks/applovin.md) para obter detalhes sobre cada rede.
+<p class="table-footnotes">
+  <span id="bidding-footnote"><sup>1</sup></span> A integração de leilão (bidding) está em versão beta.<br>
+  <span id="format-beta-sdkb-footnote"><sup>2</sup></span> Este formato está em versão beta (SDK bidding).
+</p>
 
-## Escolhendo fontes de anúncios
+!!! note "Nota"
+    As fontes de anúncios estão ordenadas alfabeticamente.
 
-Ao escolher fontes de anúncios, considere:
+## Adaptadores de código aberto e versionados
 
-- **Taxa de preenchimento (Fill rate)**: Quão bem a fonte de anúncios preenche as solicitações de anúncios em suas regiões-alvo
-- **eCPM**: O custo efetivo por mil (mil impressões) que a fonte de anúncios oferece
-- **Formatos de anúncios**: Quais formatos de anúncios a fonte de anúncios suporta
-- **Complexidade de integração**: Quão fácil é integrar a fonte de anúncios
+Se um adaptador estiver rotulado como "Código aberto e versionado" na tabela anterior, isso significa que o código-fonte do adaptador é de código aberto no repositório do Google no GitHub ([Android](https://github.com/googleads/googleads-mobile-android-mediation){:target="_blank"} ou [iOS](https://github.com/googleads/googleads-mobile-ios-mediation){:target="_blank"}), permitindo que você depure problemas por conta própria, caso deseje.
 
-## Leilão (Bidding) vs Cascata (Waterfall)
+Cada adaptador é construído para uma versão específica do SDK da rede de anúncios de terceiros. Siga o guia de integração do parceiro específico para mais detalhes.
 
-A Mediação do AdMob suporta dois métodos de integração:
+### Versionamento de adaptadores
 
-- **Leilão (Bidding)**: As fontes de anúncios competem em tempo real pelo seu inventário de anúncios. Este é o método recomendado.
-- **Cascata (Waterfall)**: As fontes de anúncios são priorizadas em uma ordem sequencial.
+Os adaptadores do Godot seguem um esquema de versionamento `<major>.<minor>.<patch>` que modela as dependências subjacentes dos SDKs do Android e iOS para essa rede de anúncios. Se a dependência do Android ou do iOS receber um aumento de versão major ou minor, o adaptador do Godot também receberá o aumento correspondente. Todos os outros lançamentos recebem um incremento de versão de patch.
 
-Para mais informações sobre leilão, consulte [Solucionar problemas de leilão](troubleshoot_bidding.md).
+!!! important "Importante"
+    Certifique-se de desativar a atualização automática (refresh) na interface de todas as redes de anúncios de terceiros para blocos de banner usados na Mediação do AdMob. Isso evita atualizações duplas, já que o AdMob também aciona a atualização com base na taxa definida no seu bloco de banner.
+
+## Otimização de fontes de anúncios
+
+Ao configurar várias redes de anúncios para mediação, é necessário definir a ordem de solicitação dessas redes configurando seus respectivos CPMs. Isso pode ser difícil de gerenciar, pois o desempenho das redes muda com o tempo.
+
+A [otimização de fontes de anúncios](https://support.google.com/admob/answer/7388022){:target="_blank"} é um recurso que permite gerar o maior CPM das redes de anúncios em sua cadeia de mediação, automatizando o ordenamento da cadeia para maximizar a receita.
+
+A [tabela de redes de mediação](#network-details) anterior usa os seguintes valores para o suporte de otimização:
+
+| Suporte de otimização de fontes de anúncios | O que significa |
+| :--- | :--- |
+| `Apenas leilão` | A rede de anúncios participa apenas do leilão (bidding). A otimização de fontes de anúncios não se aplica. |
+| `Específico por país` | Os valores de eCPM são atualizados automaticamente para você país por país. Este é o tipo ideal de otimização. |
+| `Nenhum` | Você deve configurar manualmente um valor de eCPM para essa rede de anúncios. |
+
+Clique no guia de uma rede de anúncios específica para ver detalhes sobre como configurar a otimização de fontes de anúncios para essa rede.
+
+!!! note "Nota"
+    Apenas redes de anúncios rotuladas como **Código aberto e versionado** possuem instruções específicas para configurar a otimização de fontes de anúncios.
+
+## Eventos personalizados
+
+Se você está procurando uma rede de anúncios e não a encontrou na lista acima, pode usar eventos personalizados para escrever sua própria integração com essa rede. Consulte o [guia de eventos personalizados do Google](https://developers.google.com/admob/android/mediation/custom-events){:target="_blank"} para obter mais detalhes sobre como criar um evento personalizado.
+
+!!! note "Nota"
+    Eventos personalizados não possuem suporte para otimização de fontes de anúncios nem para leilão (bidding).

--- a/docs/mediate/choose_networks.zh.md
+++ b/docs/mediate/choose_networks.zh.md
@@ -1,25 +1,561 @@
-# 选择广告源
+# 选择广告来源
 
-设置好 AdMob 中介后，你可以选择要使用的广告源。广告源是通过 AdMob 中介投放广告的第三方广告网络。
+AdMob 中介支持多种广告来源，兼顾出价 (Bidding) 和瀑布流 (Waterfall) 两种集成方式。点击广告来源即可查看该广告来源的具体集成说明。
 
-## 支持的广告源
+<table class="admob-matrix-table" id="network-details">
+  <thead>
+    <tr>
+      <th style="width: 17%;">广告来源</th>
+      <th style="width: 8%;">App<br>Open</th>
+      <th style="width: 8%;">Banner</th>
+      <th style="width: 10.5%;">Interstitial</th>
+      <th style="width: 9%;">Rewarded</th>
+      <th style="width: 11%;">Rewarded<br>Interstitial</th>
+      <th style="width: 8%;">Native</th>
+      <th style="width: 8.5%;">Bidding</th>
+      <th style="width: 20%;">广告来源优化<br>支持</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="table-section-row">
+      <th colspan="9">开放源代码且进行了版本控制 - 需要第三方 SDK</th>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/applovin.md">AppLovin</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/bidmachine.md">BidMachine</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>无</td>
+    </tr>
+    <tr>
+      <td><a href="https://developers.google.com/admob/ios/mediation/bigo" target="_blank">BIGO Ads SDK</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>无</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/chartboost.md">Chartboost</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/dtexchange.md">DT Exchange</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/imobile.md">i-mobile</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td>仅限日本</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/inmobi.md">InMobi</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/ironsource.md">ironSource Ads</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/vungle.md">Liftoff Monetize</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/line.md">LY Ads Network</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/maio.md">maio</a></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>仅限日本</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/meta.md">Meta Audience Network</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/mintegral.md">Mintegral</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/moloco.md">Moloco</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/mytarget.md">myTarget</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/pangle.md">Pangle</a></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/pubmatic.md">PubMatic OpenWrap</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#format-beta-sdkb-footnote"><sup>2</sup></a></td>
+      <td><span class="table-check">✓</span></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/unity_ads.md">Unity Ads</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span><a class="footnote" href="#bidding-footnote"><sup>1</sup></a></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr class="table-section-row">
+      <th colspan="9">非开放源代码 - 需要第三方 SDK</th>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/vpon.md">Vpon</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>无</td>
+    </tr>
+    <tr>
+      <td><a href="integrate_partner_networks/zucks.md">Zucks</a></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>针对特定国家/地区</td>
+    </tr>
+    <tr class="table-section-row">
+      <th colspan="9">不需要第三方 SDK</th>
+    </tr>
+    <tr>
+      <td>Ad Generation</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Bidease</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Chocolate Platform</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Equativ (formerly Smart Adserver)</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Fluct</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Improve Digital</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Index Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>InMobi Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Magnite DV+</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Media.net</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>MobFox</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Nativo</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Nexxen (previously UnrulyX)</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>OneTag Exchange</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>OpenX</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>PubMatic</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Rise</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Sharethrough</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Smaato</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Sonobi</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>TripleLift</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Verve Group</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>Yieldmo</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+    <tr>
+      <td>YieldOne</td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td><span class="table-check">✓</span></td>
+      <td></td>
+      <td></td>
+      <td><span class="table-check">✓</span></td>
+      <td>仅限出价</td>
+    </tr>
+  </tbody>
+</table>
 
-AdMob 中介支持广泛的广告源。有关每个网络的详细信息，请参阅[集成合作伙伴网络](integrate_partner_networks/applovin.md)列表。
+<p class="table-footnotes">
+  <span id="bidding-footnote"><sup>1</sup></span> 出价 (Bidding) 集成目前处于 Beta 测试阶段。<br>
+  <span id="format-beta-sdkb-footnote"><sup>2</sup></span> 此格式目前处于 Beta 测试阶段 (SDK bidding)。
+</p>
 
-## 选择广告源
+!!! note "注意"
+    广告来源按字母顺序排序。
 
-选择广告源时，请考虑：
+## 开放源代码且受版本控制的适配器
 
-- **填充率 (Fill rate)**：广告源在你的目标地区填充广告请求的效果如何
-- **eCPM**：广告源提供的每千次展示有效成本
-- **广告格式**：广告源支持哪些广告格式
-- **集成复杂度**：集成广告源的难易程度
+如果上表中某个适配器带有“开放源代码且进行了版本控制”标签，则表示该适配器的源代码已在 Google 的 GitHub 存储库（[Android](https://github.com/googleads/googleads-mobile-android-mediation){:target="_blank"} 或 [iOS](https://github.com/googleads/googleads-mobile-ios-mediation){:target="_blank"}）中开源，以便您可以自行排查问题。
 
-## 出价 (Bidding) 与 瀑布流 (Waterfall)
+每个适配器都针对特定版本的第三方广告联盟 SDK 构建。有关详情，请参阅各个合作伙伴的集成指南。
 
-AdMob 中介支持两种集成方法：
+### 适配器版本控制
 
-- **出价 (Bidding)**：广告源实时竞价你的广告库存。这是推荐的方法。
-- **瀑布流 (Waterfall)**：广告源按顺序进行优先级排序。
+Godot 适配器采用 `<major>.<minor>.<patch>` 版本控制架构，该架构模拟了该广告联盟的基础 Android 和 iOS SDK 依赖项。如果 Android 或 iOS 依赖项进行了主要或次要版本升级，Godot 适配器也会进行相应的版本升级。所有其他版本都会获得补丁版本升级。
 
-有关出价的更多信息，请参阅[解决出价问题](troubleshoot_bidding.md)。
+!!! important "重要提示"
+    请务必在所有第三方广告联盟的后台界面中为用于 AdMob 中介的横幅广告单元停用自动刷新。这可以防止双重刷新，因为 AdMob 也会根据横幅广告单元的刷新频率触发刷新。
+
+## 广告来源优化
+
+配置多个中介广告联盟时，您必须通过设置各自的 CPM 来指定请求这些联盟的顺序。这可能很难管理，因为广告联盟的效果会随着时间的推移而变化。
+
+[广告来源优化](https://support.google.com/admob/answer/7388022){:target="_blank"} 是一项通过自动调整中介链顺序以实现收入最大化，从而帮助您从中介链中的广告联盟获得最高 CPM 的功能。
+
+之前的[中介网络表格](#network-details)针对广告来源优化支持使用以下值：
+
+| 广告来源优化支持 | 含义 |
+| :--- | :--- |
+| `仅限出价` | 该广告联盟仅参与出价。广告来源优化不适用。 |
+| `针对特定国家/地区` | 系统会自动按国家/地区为您更新 eCPM 值。这是最理想的优化类型。 |
+| `无` | 您必须为该广告联盟手动配置 eCPM 值。 |
+
+点击各个广告联盟的指南，了解如何为该广告联盟配置广告来源优化的详细信息。
+
+!!! note "注意"
+    只有标记为**开放源代码且进行了版本控制**的广告联盟才有针对该广告联盟设置广告来源优化的具体说明。
+
+## 自定义事件
+
+如果您要找的广告联盟未包含在前面的列表中，可以使用自定义事件编写与该广告联盟的专属集成。如需详细了解如何创建自定义事件，请参阅 Google 的[自定义事件指南](https://developers.google.com/admob/android/mediation/custom-events){:target="_blank"}。
+
+!!! note "注意"
+    自定义事件不支持广告来源优化或出价 (Bidding)。

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -309,3 +309,95 @@ body {
   -webkit-mask-size: cover;
   opacity: 0.7;
 }
+
+/* 📊 MEDIATION MATRIX TABLE */
+.admob-matrix-table {
+  display: table !important;
+  width: 100% !important;
+  table-layout: fixed !important;
+  border-collapse: collapse !important;
+  font-size: 0.75rem !important;
+  margin: 1.5em 0 0.5em 0 !important;
+  line-height: 1.35 !important;
+}
+
+.admob-matrix-table thead tr {
+  background-color: #e8eaed !important;
+}
+
+[data-md-color-scheme="slate"] .admob-matrix-table thead tr {
+  background-color: #232734 !important;
+}
+
+.admob-matrix-table th,
+.admob-matrix-table td {
+  padding: 8px 3px !important;
+  text-align: center !important;
+  vertical-align: middle !important;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest) !important;
+  hyphens: none !important;
+  word-break: normal !important;
+}
+
+.admob-matrix-table th {
+  font-weight: 600 !important;
+}
+
+.admob-matrix-table th:first-child,
+.admob-matrix-table td:first-child {
+  text-align: left !important;
+  padding-left: 8px !important;
+  font-weight: 500;
+}
+
+.admob-matrix-table th:last-child,
+.admob-matrix-table td:last-child {
+  text-align: left !important;
+  padding-left: 8px !important;
+}
+
+.table-check {
+  color: #1e8e3e !important;
+  font-weight: bold !important;
+  font-size: 1.1em !important;
+}
+
+[data-md-color-scheme="slate"] .table-check {
+  color: #34a853 !important;
+}
+
+.footnote {
+  color: var(--md-typeset-a-color, #1a73e8) !important;
+  text-decoration: none !important;
+  font-size: 0.75em !important;
+  vertical-align: super !important;
+  margin-left: 2px !important;
+  font-weight: normal !important;
+}
+
+.footnote:hover {
+  text-decoration: underline !important;
+}
+
+.table-footnotes {
+  font-size: 0.78rem !important;
+  color: var(--md-default-fg-color--light) !important;
+  margin-top: 0.5em !important;
+  margin-bottom: 1.5em !important;
+  line-height: 1.5 !important;
+}
+
+.table-section-row th {
+  background-color: #f1f3f4 !important;
+  color: #202124 !important;
+  font-weight: 700 !important;
+  text-align: left !important;
+  padding: 10px 8px !important;
+  font-size: 0.8rem !important;
+  border: none !important;
+}
+
+[data-md-color-scheme="slate"] .table-section-row th {
+  background-color: #1a1d27 !important;
+  color: #e8eaed !important;
+}


### PR DESCRIPTION
### Summary
- Aligned the mediation ad sources matrix table in `docs/mediate/choose_networks.md` with official Google Mobile Ads mediation documentation ([iOS](https://developers.google.com/admob/ios/choose-networks) & [Android](https://developers.google.com/admob/android/next-gen/mediation/choose-networks)).
- Added all 9 columns: `Ad source`, `App Open`, `Banner`, `Interstitial`, `Rewarded`, `Rewarded Interstitial`, `Native`, `Bidding`, and `Ad source optimization support`.
- Made footnotes `¹` and `²` clickable links jumping to `#bidding-footnote` and `#format-beta-sdkb-footnote`.
- Styled table in `docs/stylesheets/extra.css` to fit within standard desktop width with zero word wrapping issues (preventing mid-word splits like `Banne r` or `Inter- stitial`).
- Synced all 4 localization files with 1:1 structural parity:
  - Portuguese (`docs/mediate/choose_networks.pt-BR.md`)
  - Spanish (`docs/mediate/choose_networks.es.md`)
  - Japanese (`docs/mediate/choose_networks.ja.md`)
  - Chinese (`docs/mediate/choose_networks.zh.md`)

Closes #472