### PR TITLE
docs(mediation): remove BIGO Ads SDK from choose ad sources table

### DIFF
--- a/docs/mediate/choose_networks.es.md
+++ b/docs/mediate/choose_networks.es.md
@@ -43,17 +43,6 @@ La mediación de AdMob admite varias fuentes de anuncios, que admiten integracio
       <td>Ninguno</td>
     </tr>
     <tr>
-      <td><a href="https://developers.google.com/admob/ios/mediation/bigo" target="_blank">BIGO Ads SDK</a></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td>Ninguno</td>
-    </tr>
-    <tr>
       <td><a href="integrate_partner_networks/chartboost.md">Chartboost</a></td>
       <td></td>
       <td><span class="table-check">✓</span></td>

--- a/docs/mediate/choose_networks.ja.md
+++ b/docs/mediate/choose_networks.ja.md
@@ -43,17 +43,6 @@ AdMob メディエーションは、入札 (Bidding) とウォーターフォー
       <td>なし</td>
     </tr>
     <tr>
-      <td><a href="https://developers.google.com/admob/ios/mediation/bigo" target="_blank">BIGO Ads SDK</a></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td>なし</td>
-    </tr>
-    <tr>
       <td><a href="integrate_partner_networks/chartboost.md">Chartboost</a></td>
       <td></td>
       <td><span class="table-check">✓</span></td>

--- a/docs/mediate/choose_networks.md
+++ b/docs/mediate/choose_networks.md
@@ -43,17 +43,6 @@ AdMob Mediation supports several ad sources, which accommodate integrations for 
       <td>None</td>
     </tr>
     <tr>
-      <td><a href="https://developers.google.com/admob/ios/mediation/bigo" target="_blank">BIGO Ads SDK</a></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td>None</td>
-    </tr>
-    <tr>
       <td><a href="integrate_partner_networks/chartboost.md">Chartboost</a></td>
       <td></td>
       <td><span class="table-check">✓</span></td>

--- a/docs/mediate/choose_networks.pt-BR.md
+++ b/docs/mediate/choose_networks.pt-BR.md
@@ -43,17 +43,6 @@ A Mediação do AdMob suporta várias fontes de anúncios, que acomodam integra�
       <td>Nenhum</td>
     </tr>
     <tr>
-      <td><a href="https://developers.google.com/admob/ios/mediation/bigo" target="_blank">BIGO Ads SDK</a></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td>Nenhum</td>
-    </tr>
-    <tr>
       <td><a href="integrate_partner_networks/chartboost.md">Chartboost</a></td>
       <td></td>
       <td><span class="table-check">✓</span></td>

--- a/docs/mediate/choose_networks.zh.md
+++ b/docs/mediate/choose_networks.zh.md
@@ -43,17 +43,6 @@ AdMob 中介支持多种广告来源，兼顾出价 (Bidding) 和瀑布流 (Wate
       <td>无</td>
     </tr>
     <tr>
-      <td><a href="https://developers.google.com/admob/ios/mediation/bigo" target="_blank">BIGO Ads SDK</a></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td></td>
-      <td><span class="table-check">✓</span></td>
-      <td><span class="table-check">✓</span></td>
-      <td>无</td>
-    </tr>
-    <tr>
       <td><a href="integrate_partner_networks/chartboost.md">Chartboost</a></td>
       <td></td>
       <td><span class="table-check">✓</span></td>


### PR DESCRIPTION
### Summary

- Removed BIGO Ads SDK row from the mediation ad sources matrix in `docs/mediate/choose_networks.md` and all localized variants (`.pt-BR`, `.es`, `.ja`, `.zh`).
- Reason: Google does not currently provide official Swift Package Manager (SPM) distribution for the BIGO Ads iOS mediation adapter (CocoaPods-only and currently in beta). Integration will be revisited once official SPM support is available.
