### PR TITLE
fix: resolve prebuilt export duplicate ZIP entry and validate Gradle requirement (#519)

### DIFF
--- a/platforms/godot_editor/AdMobSample.csproj
+++ b/platforms/godot_editor/AdMobSample.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Godot.NET.Sdk/4.7.2">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net9.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
 </Project>

--- a/platforms/godot_editor/addons/admob/csharp/src/Core/MobileSingletonPlugin.cs
+++ b/platforms/godot_editor/addons/admob/csharp/src/Core/MobileSingletonPlugin.cs
@@ -44,10 +44,10 @@ namespace PoingStudios.AdMob.Core
 			}
 
 			string location = osName == "Android" 
-				? "the Project Settings and 'Use Gradle Build' is enabled" 
-				: "the 'Plugins' section of the Export tab";
+				? "Project Settings (admob/general/android/enabled) and 'Use Gradle Build' is enabled in the Export Preset" 
+				: "Project Settings (admob/general/ios/enabled)";
 			
-			string message = $"{pluginName} not found, make sure it is enabled in {location}";
+			string message = $"[AdMob] Native plugin '{pluginName}' not found. Make sure it is enabled in {location}.";
 
 			if (isRequired)
 			{

--- a/platforms/godot_editor/addons/admob/gdscript/src/core/MobileSingletonPlugin.gd
+++ b/platforms/godot_editor/addons/admob/gdscript/src/core/MobileSingletonPlugin.gd
@@ -36,11 +36,14 @@ static func _get_plugin(plugin_name: String, is_required := true) -> Object:
 		return null
 
 	var location := (
-		"the Project Settings and 'Use Gradle Build' is enabled"
+		"Project Settings (admob/general/android/enabled) and 'Use Gradle Build' is enabled in the Export Preset"
 		if os_name == "Android"
-		else "the 'Plugins' section of the Export tab"
+		else "Project Settings (admob/general/ios/enabled)"
 	)
-	var message := plugin_name + " not found, make sure it is enabled in " + location
+	var message := (
+		"[AdMob] Native plugin '%s' not found. Make sure it is enabled in %s."
+		% [plugin_name, location]
+	)
 
 	if is_required:
 		printerr(message)

--- a/platforms/godot_editor/addons/admob/internal/exporters/android/export_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/exporters/android/export_plugin.gd
@@ -157,6 +157,11 @@ func _get_android_manifest_application_element_contents(
 func _export_begin(_features: PackedStringArray, _is_debug: bool, _path: String, _flags: int) -> void:
 	if not _features.has("android"):
 		return
+	if not get_option("gradle_build/use_gradle_build"):
+		push_error(
+			"AdMob Android Export Error: 'Use Gradle Build' must be enabled in the Android export preset. Prebuilt APK export is not supported by the Poing AdMob plugin."
+		)
+		return
 	PluginVersion.check_version_mismatch(PluginVersion.android_version, "Android")
 	_patch_android_gradle_file()
 

--- a/platforms/godot_editor/addons/admob/internal/exporters/main_export_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/exporters/main_export_plugin.gd
@@ -26,11 +26,16 @@ const CFG_FILE_PATH := "res://addons/admob/plugin.cfg"
 
 
 func _export_begin(features: PackedStringArray, is_debug: bool, path: String, flags: int) -> void:
-	var file = FileAccess.open(CFG_FILE_PATH, FileAccess.READ)
+	var file := FileAccess.open(CFG_FILE_PATH, FileAccess.READ)
 	if file:
 		print("Exporting Poing AdMob '.cfg' file")
 		add_file(CFG_FILE_PATH, file.get_buffer(file.get_length()), false)
-	file.close()
+		file.close()
+
+
+func _export_file(path: String, _type: String, _features: PackedStringArray) -> void:
+	if path == CFG_FILE_PATH:
+		skip()
 
 
 func _get_name() -> String:


### PR DESCRIPTION
Resolves #519

### Summary of Changes
- **Prevent Duplicate `plugin.cfg` ZIP Entry**: Implemented `_export_file` in `main_export_plugin.gd` calling `skip()` for `CFG_FILE_PATH`, preventing Godot's file crawler from adding a duplicate `assets/addons/admob/plugin.cfg` entry into prebuilt APK exports which causes `apksigner` `ApkFormatException`.
- **Validate Gradle Requirement**: In `export_plugin.gd`, added validation in `_export_begin` checking `get_option("gradle_build/use_gradle_build")`. Pushes an explicit error message informing users that Gradle Build is required for the Android AdMob plugin.
- **Improved Missing Plugin Diagnostics**: Updated `MobileSingletonPlugin.gd` and `MobileSingletonPlugin.cs` with clear, actionable error messages pointing users to Project Settings and Export Preset Gradle configuration.
- **C# TargetFramework Alignment**: Added conditional TargetFramework in `AdMobSample.csproj` for `net9.0` when targeting Android to match Godot 4.7.2 prebuilt template requirements while maintaining `net8.0` for desktop and CI builds.