### PR TITLE
ci: update poing-ai workflow concurrency

### DIFF
--- a/.github/poing.json
+++ b/.github/poing.json
@@ -1,0 +1,3 @@
+{
+  "enable_search_grounding": true
+}

--- a/.github/poing.json
+++ b/.github/poing.json
@@ -1,3 +1,0 @@
-{
-  "enable_search_grounding": true
-}

--- a/.github/workflows/poing-ai.yml
+++ b/.github/workflows/poing-ai.yml
@@ -44,12 +44,11 @@ on:
         description: 'PR or Issue number'
         required: true
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   review:
+    concurrency:
+      group: poing-ai-review-${{ inputs.number || github.event.pull_request.number || github.event.issue.number || github.ref }}
+      cancel-in-progress: true
     if: >
       (github.event_name == 'pull_request_target' && !github.event.pull_request.draft) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && (contains(github.event.comment.body, '/review') || contains(github.event.comment.body, '@poing-ai review') || contains(github.event.comment.body, '@poing-ai[bot] review'))) ||
@@ -81,6 +80,9 @@ jobs:
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
 
   triage:
+    concurrency:
+      group: poing-ai-triage-${{ inputs.number || github.event.issue.number || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     if: >
       (github.event_name == 'issues' && github.event.action == 'opened') ||
       (github.event_name == 'pull_request_target' && github.event.action == 'opened') ||
@@ -111,6 +113,9 @@ jobs:
 
   fix:
     name: Auto-Fix
+    concurrency:
+      group: poing-ai-fix-${{ inputs.number || github.event.issue.number || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     if: >
       (github.event_name == 'issues' && (
         contains(github.event.issue.labels.*.name, 'auto-fix') ||


### PR DESCRIPTION
### Summary

Updates the `poing-ai` workflow integration:

1. **Job-Level Concurrency**:
   - Moves `concurrency` from the workflow root down to each individual job (`review`, `triage`, `fix`).
   - Prevents active PR reviews from being canceled prematurely when casual comments or discussion are posted on a PR.